### PR TITLE
fix: align release-please with existing v-tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "include-v-in-tag": true,
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
## Summary
Release Please is currently generating component-prefixed tags (for example birddex-v1.3.0) while this repository's historical tags are plain vX.Y.Z.

## Problem
Because of the tag mismatch, release PR #84 is using the wrong baseline and pulling a much larger history set than intended.

## Change
- set include-component-in-tag: false at root
- set include-component-in-tag: false for package .

## Expected result
Release Please will resolve against existing plain tags (for example v1.2.0) and generate correct incremental release notes.