### PR TITLE
fix: enlarge bird detail hero image with overlay text and top-biased crop

### DIFF
--- a/src/components/pages/BirdDexPage.tsx
+++ b/src/components/pages/BirdDexPage.tsx
@@ -193,45 +193,34 @@ function SpeciesDetail({
       </div>
 
       <div className="px-4 sm:px-6 space-y-6">
-        {/* Hero: image + name + stats */}
-        <div className="flex gap-5 sm:gap-6">
-          {/* Square image — placeholder bg, image crossfades in */}
-          <div className="w-32 h-32 sm:w-40 sm:h-40 rounded-xl bg-muted overflow-hidden flex-shrink-0 shadow-sm relative">
-            {heroImage ? (
-              <img
-                src={heroImage}
-                alt={displayName}
-                className="absolute inset-0 w-full h-full object-cover animate-fade-in"
-              />
-            ) : !summaryLoading ? (
-              <div className="absolute inset-0 flex items-center justify-center">
-                <Bird size={32} className="text-muted-foreground/40" />
-              </div>
-            ) : null}
-          </div>
+        {/* Hero: full-width image with overlaid name + stats */}
+        <div className="w-full aspect-[4/3] rounded-xl bg-muted overflow-hidden shadow-sm relative">
+          {heroImage ? (
+            <img
+              src={heroImage}
+              alt={displayName}
+              className="absolute inset-0 w-full h-full object-cover object-[center_10%] animate-fade-in"
+            />
+          ) : !summaryLoading ? (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <Bird size={48} className="text-muted-foreground/40" />
+            </div>
+          ) : null}
 
-          {/* Name + inline stats — always visible (data from dex entry) */}
-          <div className="min-w-0 flex-1 flex flex-col justify-center">
-            <h2 className="font-serif text-2xl sm:text-3xl font-semibold text-foreground leading-tight">
+          {/* Gradient overlay + text at bottom */}
+          <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent pt-16 pb-4 px-4 sm:px-5">
+            <h2 className="font-serif text-2xl sm:text-3xl font-semibold text-white leading-tight drop-shadow-md">
               {displayName}
             </h2>
             {scientificName && (
-              <p className="text-sm text-muted-foreground italic mt-1">
-                {scientificName}
-              </p>
+              <p className="text-sm text-white/75 italic mt-0.5 drop-shadow-sm">{scientificName}</p>
             )}
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-3.5 text-sm text-muted-foreground">
-              <span>
-                <span className="font-semibold text-foreground">{entry.totalCount}</span> seen
-              </span>
-              <span className="text-border">·</span>
-              <span>
-                <span className="font-semibold text-foreground">{entry.totalOutings}</span> {entry.totalOutings === 1 ? 'outing' : 'outings'}
-              </span>
-              <span className="text-border">·</span>
-              <span>
-                First <span className="font-semibold text-foreground">{formatStoredDate(entry.firstSeenDate, { month: 'short', day: 'numeric', year: 'numeric' })}</span>
-              </span>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2 text-sm text-white/70">
+              <span><span className="font-semibold text-white">{entry.totalCount}</span> seen</span>
+              <span className="text-white/40">·</span>
+              <span><span className="font-semibold text-white">{entry.totalOutings}</span> {entry.totalOutings === 1 ? 'outing' : 'outings'}</span>
+              <span className="text-white/40">·</span>
+              <span>First <span className="font-semibold text-white">{formatStoredDate(entry.firstSeenDate, { month: 'short', day: 'numeric', year: 'numeric' })}</span></span>
             </div>
           </div>
         </div>

--- a/src/components/ui/bird-row.tsx
+++ b/src/components/ui/bird-row.tsx
@@ -20,7 +20,7 @@ export function BirdRow({ speciesName, subtitle, onClick, actions }: BirdRowProp
     <img
       src={wikiImage}
       alt={displayName}
-      className="w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-lg object-cover bg-muted flex-shrink-0"
+      className="w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-lg object-cover object-[center_10%] bg-muted flex-shrink-0"
     />
   ) : (
     <div className="w-14 h-14 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-lg bg-muted flex items-center justify-center flex-shrink-0">


### PR DESCRIPTION
## Summary

Fixes #92 — Bird detail page pic should be bigger.

### Changes

- **Full-width hero image**: Replaced the small 128–160px square with a full-width `aspect-[4/3]` hero image
- **Overlaid text**: Bird name, scientific name, and stats are overlaid on the image with a gradient (`from-black/70 → transparent`) for readability
- **Top-biased crop**: `object-position: center 10%` keeps bird heads visible when portrait images are cropped to landscape
- **Thumbnails**: Applied the same top-biased crop to BirdRow list thumbnails

### Before / After

**Before**: Small square image next to text

<img width="400" alt="before" src="https://github.com/user-attachments/assets/5139aa0b-255f-410a-9283-aee5399d5c96" />

**After**: Full-width hero with gradient overlay text

<img width="400" alt="after" src="https://github.com/user-attachments/assets/af9b4c29-75e0-4f79-95e1-115d9de71f34" />