### PR TITLE
ci: make the no PR release work

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,3 +28,10 @@ jobs:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Auto-merge release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: gh pr merge ${{ fromJson(steps.release.outputs.pr).number }} --auto --squash


### PR DESCRIPTION
## Summary

`skip-github-pull-request: true` is broken ([googleapis/release-please-action#937](https://github.com/googleapis/release-please-action/issues/937)) — release-please silently no-ops with this flag.

### Changes
- Reverted `skip-github-pull-request: true` and restored standard PR-based release workflow
- Added `pull-requests: write` permission
- Added auto-merge step: after release-please creates a release PR, `gh pr merge --auto --squash` merges it automatically once CI passes

### Flow
CI passes on main → release-please creates release PR → auto-merge enabled → CI runs on PR → PR merges automatically → release-please creates GitHub release

No manual PR management needed.

> **Note:** Requires "Allow auto-merge" enabled in repo Settings → General → Pull Requests.