### PR TITLE
feat: rename BirdDex to WingDex across app

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,10 +78,10 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 Goal: avoid pushing follow-up commits that miss existing reviewer feedback.
 
-## 7. Repository Defaults (BirdDex)
+## 7. Repository Defaults (WingDex)
 
 For repository-specific CLI commands in this workspace, use these defaults unless the user specifies otherwise:
 
-- Owner/repo: `jlian/birddex`
+- Owner/repo: `jlian/wingdex`
 - Default branch: `main`
 - Active PR checks may include semantic PR title validation requiring Conventional Commit style titles (e.g., `fix: ...`).

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,6 +16,7 @@
       "type": "shell",
       "command": "npm",
       "args": [
+        "--silent",
         "run",
         "setup:playwright"
       ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 * use plain v tags for release-please ([#85](https://github.com/jlian/birddex/issues/85)) ([ab4a2da](https://github.com/jlian/birddex/commit/ab4a2da3df3de4abb6e16589010b1a48f70bcd4f))
 
-## 1.2.0 (2026-02-16)
+## [1.2.0](https://github.com/jlian/birddex/compare/v1.1.0...v1.2.0) (2026-02-16)
 
 ### Features
 - replace stat cards with compact inline stats on homepage ([3908041](https://github.com/jlian/birddex/commit/3908041))
@@ -135,7 +135,7 @@
 - Load PWA manifest from bundled asset to avoid Spark 404 ([0299465](https://github.com/jlian/birddex/commit/0299465))
 - Harden iOS home-screen icon metadata and cache-bust touch icon ([7bdb77e](https://github.com/jlian/birddex/commit/7bdb77e))
 
-## 1.1.0 (2026-02-15)
+## [1.1.0](https://github.com/jlian/birddex/compare/v1.0.2...v1.1.0) (2026-02-15)
 
 ### Features
 - extract saved locations from eBird CSV import ([3cd4b05](https://github.com/jlian/birddex/commit/3cd4b05))
@@ -164,12 +164,12 @@
 - Pass location name to bird ID prompt for regional species accuracy (#30) ([30c7b03](https://github.com/jlian/birddex/commit/30c7b03))
 - Replace saved locations with outing name autocomplete (#41) ([dfe28f7](https://github.com/jlian/birddex/commit/dfe28f7))
 
-## 1.0.2 (2026-02-13)
+## [1.0.2](https://github.com/jlian/birddex/compare/v1.0.1...v1.0.2) (2026-02-13)
 
 ### Bug Fixes
 - eBird links, taxonomy grounding, and Wikipedia coverage ([5b1cb31](https://github.com/jlian/birddex/commit/5b1cb31))
 
-## 1.0.1 (2026-02-13)
+## [1.0.1](https://github.com/jlian/birddex/compare/v1.0.0...v1.0.1) (2026-02-13)
 
 ### Features
 - harden user isolation and auth guard ([79cbee7](https://github.com/jlian/birddex/commit/79cbee7))
@@ -184,7 +184,7 @@
 - stabilize spark resolution and CI install mode ([f93cc93](https://github.com/jlian/birddex/commit/f93cc93))
 - sync settings version from package.json ([3cf43aa](https://github.com/jlian/birddex/commit/3cf43aa))
 
-## 1.0.0 (2026-02-13)
+## [1.0.0](https://github.com/jlian/birddex/compare/v0.9.0...v1.0.0) (2026-02-13)
 
 ### Highlights
 - Reached first stable major release with core BirdDex flows: dark mode, outing title editing, and eBird record-format export.
@@ -254,7 +254,7 @@
 
 </details>
 
-## 0.9.0 (2026-02-13)
+## [0.9.0](https://github.com/jlian/birddex/compare/v0.8.0...v0.9.0) (2026-02-13)
 
 ### Features
 - Add eBird taxonomy for species autocomplete and AI grounding ([e2990d8](https://github.com/jlian/birddex/commit/e2990d8))
@@ -277,7 +277,7 @@
 ### Continuous Integration
 - run all tests instead of hardcoded subset ([4c9ec46](https://github.com/jlian/birddex/commit/4c9ec46))
 
-## 0.8.0 (2026-02-13)
+## [0.8.0](https://github.com/jlian/birddex/compare/v0.7.0...v0.8.0) (2026-02-13)
 
 ### Bug Fixes
 - align react-dom version with react to fix #527 mismatch error ([8c2b23b](https://github.com/jlian/birddex/commit/8c2b23b))
@@ -291,12 +291,12 @@
 - Bump react-resizable-panels from 2.1.9 to 4.6.2 (#2) ([d7d56e2](https://github.com/jlian/birddex/commit/d7d56e2))
 - Bump eslint-plugin-react-hooks from 5.2.0 to 7.0.1 (#3) ([0c813b2](https://github.com/jlian/birddex/commit/0c813b2))
 
-## 0.7.0 (2026-02-13)
+## [0.7.0](https://github.com/jlian/birddex/compare/v0.6.0...v0.7.0) (2026-02-13)
 
 ### Miscellaneous Chores
 - eBird import creates outings, add import instructions, confetti on new species ([936e4e8](https://github.com/jlian/birddex/commit/936e4e8))
 
-## 0.6.0 (2026-02-13)
+## [0.6.0](https://github.com/jlian/birddex/compare/v0.5.0...v0.6.0) (2026-02-13)
 
 ### Code Refactoring
 - extract shared utilities, remove dead code ([cc491d3](https://github.com/jlian/birddex/commit/cc491d3))
@@ -308,7 +308,7 @@
 - Polish detail pages, fix nav bug, reorder settings, clean up stale files ([b838f76](https://github.com/jlian/birddex/commit/b838f76))
 - Update docs, fix CI console error filter, remove UX_FIXES.md ([ac4d5f1](https://github.com/jlian/birddex/commit/ac4d5f1))
 
-## 0.5.0 (2026-02-13)
+## [0.5.0](https://github.com/jlian/birddex/compare/v0.4.0...v0.5.0) (2026-02-13)
 
 ### Features
 - consistent cards, animations, seed data, delete data ([59906bd](https://github.com/jlian/birddex/commit/59906bd))
@@ -319,7 +319,7 @@
 ### Miscellaneous Chores
 - Compact Merlin-style rows, sorting, tighter spacing, logo nav ([e4aacae](https://github.com/jlian/birddex/commit/e4aacae))
 
-## 0.4.0 (2026-02-13)
+## [0.4.0](https://github.com/jlian/birddex/compare/v0.3.0...v0.4.0) (2026-02-13)
 
 ### Features
 - outing detail view, saved locations UI, title/favicon, PRD updates ([1750b7a](https://github.com/jlian/birddex/commit/1750b7a))
@@ -328,7 +328,7 @@
 ### Miscellaneous Chores
 - add implementation status + priorities; stop persisting photo blobs to KV ([1371660](https://github.com/jlian/birddex/commit/1371660))
 
-## 0.3.0 (2026-02-13)
+## [0.3.0](https://github.com/jlian/birddex/compare/v0.2.0...v0.3.0) (2026-02-13)
 
 ### Features
 - Add Playwright smoke tests (7 tests: load, nav, dialog, mobile viewport) ([11161ea](https://github.com/jlian/birddex/commit/11161ea))
@@ -336,14 +336,14 @@
 ### Miscellaneous Chores
 - UX overhaul: reverse-birding identity, Wikimedia images, outing merging, 8hr clustering ([70623fa](https://github.com/jlian/birddex/commit/70623fa))
 
-## 0.2.0 (2026-02-13)
+## [0.2.0](https://github.com/jlian/birddex/compare/v0.1.0...v0.2.0) (2026-02-13)
 
 ### Bug Fixes
 - Fix mobile crop, rework bird ID flow, add AI zoom, add tests ([ed04cbc](https://github.com/jlian/birddex/commit/ed04cbc))
 - Fix 11 UX issues: crop overlay, back nav, accessibility, error handling ([a8a4c9a](https://github.com/jlian/birddex/commit/a8a4c9a))
 - Fix AI zoom: use canvas crop instead of broken CSS percentage math ([b61dbc8](https://github.com/jlian/birddex/commit/b61dbc8))
 
-## 0.1.0 (2026-02-12)
+## [0.1.0](https://github.com/jlian/birddex/releases/tag/v0.1.0) (2026-02-12)
 
 ### Highlights
 - Bootstrapped the first working BirdDex prototype in Spark, including initial app structure and storage setup.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to BirdDex
+# Contributing to WingDex
 
 Thanks for your interest in contributing! Here's how to get started.
 
@@ -6,8 +6,8 @@ Thanks for your interest in contributing! Here's how to get started.
 
 1. **Clone the repo**
    ```bash
-   git clone https://github.com/jlian/birddex.git
-   cd birddex
+   git clone https://github.com/jlian/wingdex.git
+   cd wingdex
    npm ci
    ```
 
@@ -59,7 +59,7 @@ Key areas:
 
 ## Reporting Issues
 
-- Use [GitHub Issues](https://github.com/jlian/birddex/issues) to report bugs or suggest features
+- Use [GitHub Issues](https://github.com/jlian/wingdex/issues) to report bugs or suggest features
 - Include steps to reproduce for bugs
 - Screenshots are welcome
 

--- a/PRD.md
+++ b/PRD.md
@@ -1,15 +1,15 @@
-# BirdDex: Photo-First Bird Identification
+# WingDex: Photo-First Bird Identification
 
-A mobile-first web application for **reverse birders** — people who take photos first and identify species later. Upload your bird photos, let AI do the identification, confirm with one tap, and build your BirdDex over time.
+A mobile-first web application for **reverse birders** — people who take photos first and identify species later. Upload your bird photos, let AI do the identification, confirm with one tap, and build your WingDex over time.
 
 **Experience Qualities**:
 1. **Photo-first** – The workflow starts with photos you already took. No checklists, no planning — just upload and go
 2. **Effortless** - Upload multiple photos at once and let AI do the heavy lifting of species identification, requiring only confirmation from the user
 3. **Scientific** - Precise data tracking with EXIF metadata extraction, GPS coordinates, timestamps, and eBird CSV compatibility for serious birding records
-4. **Delightful** - Celebrate birding achievements with a Merlin-inspired BirdDex that showcases bird photography (via Wikimedia Commons) and sighting milestones
+4. **Delightful** - Celebrate birding achievements with a Merlin-inspired WingDex that showcases bird photography (via Wikimedia Commons) and sighting milestones
 
 **Complexity Level**: Complex Application (advanced functionality, likely with multiple views)
-- Multi-screen workflow with photo upload, EXIF parsing, AI inference, data management, import/export, and synchronized state across multiple interconnected data models (Photos, Outings, Observations, BirdDex entries)
+- Multi-screen workflow with photo upload, EXIF parsing, AI inference, data management, import/export, and synchronized state across multiple interconnected data models (Photos, Outings, Observations, WingDex entries)
 
 ## Essential Features
 
@@ -46,25 +46,25 @@ A mobile-first web application for **reverse birders** — people who take photo
 - **Purpose**: Maintain data accuracy by requiring human confirmation while preserving AI suggestions for learning
 - **Trigger**: After species suggestions are generated
 - **Progression**: Suggestions displayed → Tap species to expand → View supporting photos → Tap "Confirm" / "Possible" / "Reject" → Adjust count if needed → Select best photo → Save outing
-- **Success criteria**: All confirmed species saved to outing; representative photos linked; counts accurate; rejected species not added to BirdDex
+- **Success criteria**: All confirmed species saved to outing; representative photos linked; counts accurate; rejected species not added to WingDex
 
-### 6. BirdDex Management (Merlin-like UX)
+### 6. WingDex Management (Merlin-like UX)
 - **Functionality**: Maintain per-user aggregate of all confirmed species with first seen date, last seen date, total sightings, total count; display Wikimedia Commons bird images for each species as reference photos (since user photos cannot persist in KV storage)
 - **Purpose**: Provide a beautiful, searchable record of birding accomplishments over time with real bird imagery
-- **Trigger**: Navigate to "BirdDex" tab
-- **Progression**: Tap BirdDex → Scrollable/searchable species list loads → Each entry shows species name + Wikipedia bird image + stats → Tap species → Detail view with timeline of all sightings
-- **Success criteria**: BirdDex updates in real-time as outings are saved; search filters species instantly; Wikipedia images load for recognized species; graceful fallback when images unavailable
+- **Trigger**: Navigate to "WingDex" tab
+- **Progression**: Tap WingDex → Scrollable/searchable species list loads → Each entry shows species name + Wikipedia bird image + stats → Tap species → Detail view with timeline of all sightings
+- **Success criteria**: WingDex updates in real-time as outings are saved; search filters species instantly; Wikipedia images load for recognized species; graceful fallback when images unavailable
 
 ### 7. eBird CSV Import
-- **Functionality**: Upload eBird "My eBird Data" export CSV; parse species, date, location, count columns; show preview with conflict resolution; merge into BirdDex
-- **Purpose**: Allow users to bring existing eBird history into BirdDex without re-entering data
+- **Functionality**: Upload eBird "My eBird Data" export CSV; parse species, date, location, count columns; show preview with conflict resolution; merge into WingDex
+- **Purpose**: Allow users to bring existing eBird history into WingDex without re-entering data
 - **Trigger**: User taps "Import from eBird" in settings/export screen
-- **Progression**: Import screen → Choose file → CSV parsed → Show preview table → Map columns if needed → Resolve conflicts (prefer newer dates, skip exact duplicates) → Confirm import → Data merged into BirdDex and Outings
-- **Success criteria**: Standard eBird CSV formats parsed correctly; BirdDex first/last dates updated; imported outings created; no data loss or duplication
+- **Progression**: Import screen → Choose file → CSV parsed → Show preview table → Map columns if needed → Resolve conflicts (prefer newer dates, skip exact duplicates) → Confirm import → Data merged into WingDex and Outings
+- **Success criteria**: Standard eBird CSV formats parsed correctly; WingDex first/last dates updated; imported outings created; no data loss or duplication
 
 ### 8. eBird CSV Export
 - **Functionality**: Export any outing in eBird Record Format CSV (one row per species with date, time, location, count, comments)
-- **Purpose**: Submit BirdDex sightings to eBird to maintain synchronized records across platforms
+- **Purpose**: Submit WingDex sightings to eBird to maintain synchronized records across platforms
 - **Trigger**: User taps "Export to eBird" on an outing detail screen
 - **Progression**: Outing detail → Tap export icon → Choose "eBird Format" → CSV generated → Download/share dialog → File saved/shared
 - **Success criteria**: Generated CSV matches eBird Record Format specification; imports successfully into eBird; all species, counts, and locations preserved
@@ -84,10 +84,10 @@ A mobile-first web application for **reverse birders** — people who take photo
 - **Success criteria**: All outings displayed; detail view loads quickly; photos displayed in grid; notes editable
 
 ### 11. Cloud Data Storage
-- **Functionality**: Structured data (outings, observations, BirdDex, saved spots) is stored via Spark's KV store, scoped per GitHub user ID; falls back to localStorage when KV is unavailable. User-uploaded photos are ephemeral — used only during the identification session and not persisted long-term. Bird imagery in the BirdDex and outing views comes from Wikimedia Commons
+- **Functionality**: Structured data (outings, observations, WingDex, saved spots) is stored via Spark's KV store, scoped per GitHub user ID; falls back to localStorage when KV is unavailable. User-uploaded photos are ephemeral — used only during the identification session and not persisted long-term. Bird imagery in the WingDex and outing views comes from Wikimedia Commons
 - **Purpose**: Zero-configuration cloud persistence for birding records; photo storage limitations are sidestepped by using public-domain reference images
 - **Trigger**: Automatic — no user action required
-- **Success criteria**: Outing/observation/BirdDex data persists between sessions; Wikimedia images provide visual context after photo data URLs expire; each user's data isolated by user ID; no manual backup steps needed
+- **Success criteria**: Outing/observation/WingDex data persists between sessions; Wikimedia images provide visual context after photo data URLs expire; each user's data isolated by user ID; no manual backup steps needed
 
 ## Implementation Status
 
@@ -98,9 +98,9 @@ A mobile-first web application for **reverse birders** — people who take photo
 | #3 Outing Clustering | ✅ Done | 8hr/10km thresholds, merge with existing outings |
 | #4 AI Species ID + Crop | ✅ Done | Single GPT-4.1 call returns candidates + bounding box |
 | #5 Observation Confirmation | ✅ Done | Confirm/Possible/Skip during wizard + post-save delete + manual species entry |
-| #6 BirdDex | ✅ Done | Display + search + sort + Wikimedia images + species detail with hero, stat cards, sighting history, Wikipedia/eBird/AllAboutBirds links |
-| #7 eBird Import | ⚠️ Basic | Parses CSV into BirdDex entries; doesn't create outings |
-| #8 eBird Export | ✅ Done | BirdDex CSV export + per-outing eBird CSV export from outing detail |
+| #6 WingDex | ✅ Done | Display + search + sort + Wikimedia images + species detail with hero, stat cards, sighting history, Wikipedia/eBird/AllAboutBirds links |
+| #7 eBird Import | ⚠️ Basic | Parses CSV into WingDex entries; doesn't create outings |
+| #8 eBird Export | ✅ Done | WingDex CSV export + per-outing eBird CSV export from outing detail |
 | #9 Saved Locations | ✅ Done | Add/delete spots with name, lat/lon, geolocation, Google Maps links, outing count in Settings |
 | #10 Outing Detail | ✅ Done | Tappable cards → species list, Wikimedia images, notes editing, manual add, per-outing export, delete |
 | #11 Cloud Storage | ✅ Done | Photo blobs stripped before KV persist; only metadata stored |
@@ -108,7 +108,7 @@ A mobile-first web application for **reverse birders** — people who take photo
 
 ## Upcoming Priorities
 
-1. **eBird import → outings** — Create outing records from imported eBird CSV checklists (currently imports to BirdDex only)
+1. **eBird import → outings** — Create outing records from imported eBird CSV checklists (currently imports to WingDex only)
 2. **Autocomplete for manual species entry** — eBird taxonomy or local search
 3. **Animations** — Staggered card reveals, new-species celebration, spring transitions
 
@@ -162,23 +162,23 @@ Typography should balance scientific precision with approachable readability, us
 
 ## Animations
 
-Animations should feel organic and nature-inspired, with gentle easing that mimics the movement of birds in flight. Use motion to guide attention during the multi-step upload workflow and celebrate BirdDex milestones.
+Animations should feel organic and nature-inspired, with gentle easing that mimics the movement of birds in flight. Use motion to guide attention during the multi-step upload workflow and celebrate WingDex milestones.
 
 Key animation moments:
 - Photo upload: Cards fade in with staggered timing (50ms offset), scale from 95% to 100%
 - Species suggestions: Slide up from bottom with spring physics, confidence bars animate in
-- BirdDex add: Confetti burst + gentle scale pulse when new species confirmed
+- WingDex add: Confetti burst + gentle scale pulse when new species confirmed
 - Outing transitions: Smooth page slides with momentum-based easing
 - Loading states: Organic pulse (not mechanical spin) with subtle scale variation
 
 ## Component Selection
 
 - **Components**:
-  - **Card**: Outing cards, species cards, BirdDex entries - add subtle shadow and hover lift effect
+  - **Card**: Outing cards, species cards, WingDex entries - add subtle shadow and hover lift effect
   - **Button**: Primary actions use solid accent color; secondary use outline style with primary color
   - **Dialog**: Outing review, species confirmation, import preview - full-height on mobile
   - **Sheet**: Bottom sheet for quick actions (merge outings, set location) - native feel on mobile
-  - **Tabs**: Main navigation (Home, Outings, BirdDex, Settings) - sticky header on mobile
+  - **Tabs**: Main navigation (Home, Outings, WingDex, Settings) - sticky header on mobile
   - **Input** + **Textarea**: Location name, notes, counts - large touch targets (min 44px)
   - **Badge**: Species status (Confirmed/Possible), new species indicator - use accent color
   - **Progress**: Upload progress, inference progress - organic appearance with gradient
@@ -209,7 +209,7 @@ Key animation moments:
   - Check: CheckCircle (confirm species)
   - Question: Question (mark as possible)
   - Close: X (reject species)
-  - List: List (BirdDex, outings list)
+  - List: List (WingDex, outings list)
   - Export: Download (export actions)
   - Import: Upload (import actions)
   - Settings: Gear (settings screen)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# BirdDex
+# WingDex
 
-A photo-first bird identification and life list tracker built on [GitHub Spark](https://github.com/features/spark). Upload your bird photos, let AI identify the species, and build your personal BirdDex over time.
+A photo-first bird identification and life list tracker built on [GitHub Spark](https://github.com/features/spark). Upload your bird photos, let AI identify the species, and build your personal WingDex over time.
 
-**[Try it →](https://birddex--jlian.github.app)**
+**[Try it →](https://wingdex--jlian.github.app)**
 
 <img width="1133" height="913" alt="image" src="https://github.com/user-attachments/assets/86636186-bef4-45cb-becc-3760ff9951c2" />
 
-## What is BirdDex?
+## What is WingDex?
 
-BirdDex is for **reverse birding**: people who take photos first and identify species later. Instead of checklists and field guides, you upload photos you already took, and AI handles the species identification. You just confirm with a tap.
+WingDex is for **reverse birding**: people who take photos first and identify species later. Instead of checklists and field guides, you upload photos you already took, and AI handles the species identification. You just confirm with a tap.
 
-**Your photos are never stored.** They're used only during identification and immediately discarded. Upload a whole day's worth of photos at once via the **batch upload wizard**, which clusters them into outings, identifies each bird, and lets you confirm results in one flow. Every species in your BirdDex links back to the outings where you saw it, and every outing links to its species in the BirdDex — so you can always **cross-reference between your BirdDex and your field trips**.
+**Your photos are never stored.** They're used only during identification and immediately discarded. Upload a whole day's worth of photos at once via the **batch upload wizard**, which clusters them into outings, identifies each bird, and lets you confirm results in one flow. Every species in your WingDex links back to the outings where you saw it, and every outing links to its species in the WingDex — so you can always **cross-reference between your WingDex and your field trips**.
 
 ### Features
 
@@ -18,7 +18,7 @@ BirdDex is for **reverse birding**: people who take photos first and identify sp
 - **Batch upload** - Drop a day's photos; they're auto-grouped into outings by time/GPS proximity, merged with existing sessions, and deduplicated by hash
 - **EXIF extraction** - GPS, timestamps, and thumbnails parsed client-side
 - **AI species ID** - GPT-4.1 vision returns ranked candidates with confidence scores and bounding boxes, grounded against ~11,000 eBird species
-- **BirdDex Life list** - First/last seen, total sightings, Wikipedia imagery; searchable and sortable
+- **WingDex Life list** - First/last seen, total sightings, Wikipedia imagery; searchable and sortable
 - **Species detail** - Hero image, Wikipedia summary, sighting history, and links to eBird / All About Birds
 - **Outing management** - Editable locations/notes, taxonomy autocomplete, per-observation delete, eBird CSV export, Google Maps links
 - **eBird integration** - Import/export checklists and life lists in eBird Record Format
@@ -33,7 +33,7 @@ BirdDex is for **reverse birding**: people who take photos first and identify sp
 3. **Review** the outing — confirm date, location (auto-geocoded), and notes
 4. **AI identifies** each bird with ranked suggestions, confidence scores, and a crop box
 5. **Confirm** — accept, mark as possible, pick an alternative, re-crop, or skip
-6. **Saved** to your BirdDex with species, count, and confidence
+6. **Saved** to your WingDex with species, count, and confidence
 
 ## Tech stack
 
@@ -56,15 +56,15 @@ This is a GitHub Spark app. The recommended way to develop is inside Spark's Cod
 ### Running locally
 
 ```bash
-git clone https://github.com/jlian/birddex.git
-cd birddex
+git clone https://github.com/jlian/wingdex.git
+cd wingdex
 npm ci
 npm run dev
 ```
 
 For reproducible installs and stable lockfile output, use `Node 22.16.x` and `npm 10.9.x`.
 
-> **Note:** AI features (bird detection, species ID) require the `/_spark/llm` proxy and will not work outside of the Spark runtime. Everything else (photo upload, EXIF parsing, outing management, BirdDex browsing) works normally.
+> **Note:** AI features (bird detection, species ID) require the `/_spark/llm` proxy and will not work outside of the Spark runtime. Everything else (photo upload, EXIF parsing, outing management, WingDex browsing) works normally.
 
 ### Scripts
 
@@ -93,9 +93,9 @@ In Codespaces, `.vscode/tasks.json` runs `bootstrap-workspace` on folder open to
 
 ## Security notes
 
-- BirdDex is designed for **low-sensitivity personal birding data** (outings, observations, notes).
+- WingDex is designed for **low-sensitivity personal birding data** (outings, observations, notes).
 - Data separation is implemented with **user-scoped storage keys** (for example `u123_photos`) and app-level runtime checks.
-- In hosted Spark runtime, BirdDex requires a valid Spark user session and does not fall back to a shared dev identity.
+- In hosted Spark runtime, WingDex requires a valid Spark user session and does not fall back to a shared dev identity.
 - In local/dev runtime, storage uses browser localStorage and should be treated as development-only data storage.
 - If you need strong tenant isolation for sensitive data, use a backend that enforces per-user access server-side.
 

--- a/e2e/csv-and-upload-integration.spec.ts
+++ b/e2e/csv-and-upload-integration.spec.ts
@@ -113,8 +113,8 @@ test.describe('CSV import + photo upload integration', () => {
       page.locator('p:visible', { hasText: 'Discovery Park' }).first()
     ).toBeVisible()
 
-    // Navigate to BirdDex to verify species
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click()
+    // Navigate to WingDex to verify species
+    await page.getByRole('tab', { name: 'WingDex' }).first().click()
     await expect(page.locator('p:visible', { hasText: 'species observed' }).first()).toBeVisible({ timeout: 5_000 })
 
     // All 4 species from the CSV should be in the dex
@@ -125,7 +125,7 @@ test.describe('CSV import + photo upload integration', () => {
     }
   })
 
-  test('full photo upload flow: upload → AI identify → confirm → saved to BirdDex', async ({ page }) => {
+  test('full photo upload flow: upload → AI identify → confirm → saved to WingDex', async ({ page }) => {
     await mockLLM(page, 'Chukar_partridge_near_Haleakala_summit_Maui')
     await mockNominatim(page, 'Haleakala National Park, Maui')
     await mockWikimedia(page)
@@ -161,8 +161,8 @@ test.describe('CSV import + photo upload integration', () => {
     // Wait for dialog to auto-close
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 })
 
-    // Navigate to BirdDex to verify the species was saved
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click()
+    // Navigate to WingDex to verify the species was saved
+    await page.getByRole('tab', { name: 'WingDex' }).first().click()
     await expect(page.locator('p:visible', { hasText: 'species observed' }).first()).toBeVisible({ timeout: 5_000 })
 
     await expect(
@@ -184,7 +184,7 @@ test.describe('CSV import + photo upload integration', () => {
     await expect(page.getByText(/Imported.*species/)).not.toBeVisible({ timeout: 10_000 })
 
     // Verify Chukar is in the dex from CSV
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click()
+    await page.getByRole('tab', { name: 'WingDex' }).first().click()
     await expect(page.locator('p:visible', { hasText: 'species observed' }).first()).toBeVisible({ timeout: 5_000 })
     await expect(page.locator('p:visible', { hasText: 'Chukar' }).first()).toBeVisible()
 
@@ -215,8 +215,8 @@ test.describe('CSV import + photo upload integration', () => {
     // Dialog auto-closes after species save
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15_000 })
 
-    // Go to BirdDex — Chukar should still be there (converged, not duplicated)
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click()
+    // Go to WingDex — Chukar should still be there (converged, not duplicated)
+    await page.getByRole('tab', { name: 'WingDex' }).first().click()
     await expect(page.locator('p:visible', { hasText: 'species observed' }).first()).toBeVisible({ timeout: 5_000 })
 
     // Count the Chukar entries — should be exactly 1 (not 2 separate entries)

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -10,7 +10,7 @@ export function buildSeedLocalStorage(): Record<string, string> {
   const now = Date.now()
   const day = 86400000
   const hour = 3600000
-  const prefix = 'birddex_kv_u1_'
+  const prefix = 'wingdex_kv_u1_'
 
   const outings = [
     { id: 'outing_seed_1', userId: 'seed', startTime: new Date(now - 2 * day).toISOString(), endTime: new Date(now - 2 * day + 2 * hour).toISOString(), locationName: 'Central Park, New York', lat: 40.7829, lon: -73.9654, notes: 'Beautiful morning walk along the lake.', createdAt: new Date(now - 2 * day).toISOString() },
@@ -100,11 +100,11 @@ export async function injectSeedData(page: Page) {
   await page.goto('/')
   await page.evaluate((data) => {
     // Force the dev user ID to 1 so it matches our seed key prefix (u1_)
-    localStorage.setItem('birddex_dev_user_id', '1')
+    localStorage.setItem('wingdex_dev_user_id', '1')
     for (const [key, value] of Object.entries(data)) {
       localStorage.setItem(key, value)
     }
   }, seedData)
   await page.reload()
-  await page.waitForSelector('text=BirdDex', { timeout: 10000 })
+  await page.waitForSelector('text=WingDex', { timeout: 10000 })
 }

--- a/e2e/seeded-app.spec.ts
+++ b/e2e/seeded-app.spec.ts
@@ -44,10 +44,10 @@ test.describe('App with seeded data', () => {
     await expect(page.locator('p:visible', { hasText: 'Northern Cardinal' }).first()).toBeVisible()
   })
 
-  test('birddex page lists species with count', async ({ page }) => {
+  test('wingdex page lists species with count', async ({ page }) => {
     await injectSeedData(page)
 
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click()
+    await page.getByRole('tab', { name: 'WingDex' }).first().click()
     await expect(page.locator('p:visible', { hasText: 'species observed' }).first()).toBeVisible({ timeout: 5_000 })
 
     // Known seed species should appear in the list
@@ -55,10 +55,10 @@ test.describe('App with seeded data', () => {
     await expect(page.locator('p:visible', { hasText: 'Bald Eagle' }).first()).toBeVisible()
   })
 
-  test('birddex search filters species', async ({ page }) => {
+  test('wingdex search filters species', async ({ page }) => {
     await injectSeedData(page)
 
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click()
+    await page.getByRole('tab', { name: 'WingDex' }).first().click()
     await expect(page.locator('p:visible', { hasText: 'species observed' }).first()).toBeVisible({ timeout: 5_000 })
 
     // Search for "hawk"
@@ -73,7 +73,7 @@ test.describe('App with seeded data', () => {
   test('clicking a species opens its detail view', async ({ page }) => {
     await injectSeedData(page)
 
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click()
+    await page.getByRole('tab', { name: 'WingDex' }).first().click()
     await expect(page.locator('p:visible', { hasText: 'species observed' }).first()).toBeVisible({ timeout: 5_000 })
 
     await page.locator('p:visible', { hasText: 'Northern Cardinal' }).first().click()
@@ -88,7 +88,7 @@ test.describe('App with seeded data', () => {
   test('species detail view loads Wikipedia image', async ({ page }) => {
     await injectSeedData(page)
 
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click()
+    await page.getByRole('tab', { name: 'WingDex' }).first().click()
     await expect(page.locator('p:visible', { hasText: 'species observed' }).first()).toBeVisible({ timeout: 5_000 })
 
     await page.locator('p:visible', { hasText: 'Northern Cardinal' }).first().click()

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -9,8 +9,8 @@ test.describe('App smoke tests', () => {
     const header = page.locator('header');
     await expect(header).toBeVisible({ timeout: 10_000 });
 
-    // Header should have the BirdDex tab in nav
-    await expect(header.getByText('BirdDex')).toBeVisible();
+    // Header should have the WingDex tab in nav
+    await expect(header.getByText('WingDex')).toBeVisible();
   });
 
   test('renders top nav tabs', async ({ page }) => {
@@ -20,7 +20,7 @@ test.describe('App smoke tests', () => {
     // On desktop (default viewport), nav tabs are in the header
     const header = page.locator('header');
     await expect(header.getByText('Outings')).toBeVisible();
-    await expect(header.getByText('BirdDex')).toBeVisible();
+    await expect(header.getByText('WingDex')).toBeVisible();
   });
 
   test('can navigate between tabs', async ({ page }) => {
@@ -33,10 +33,10 @@ test.describe('App smoke tests', () => {
       page.getByText('Your Outings').or(page.getByText('No outings yet'))
     ).toBeVisible({ timeout: 5_000 });
 
-    // Click BirdDex tab
-    await page.getByRole('tab', { name: 'BirdDex' }).first().click();
+    // Click WingDex tab
+    await page.getByRole('tab', { name: 'WingDex' }).first().click();
     await expect(
-      page.getByText('Your BirdDex is empty').or(page.getByRole('heading', { name: 'BirdDex' }))
+      page.getByText('Your WingDex is empty').or(page.getByRole('heading', { name: 'WingDex' }))
     ).toBeVisible({ timeout: 5_000 });
 
     // Open Settings via avatar button

--- a/index.html
+++ b/index.html
@@ -4,27 +4,27 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BirdDex</title>
+    <title>WingDex</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />
     <link rel="icon" type="image/png" sizes="512x512" href="/icon-512.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon-v2.png" />
     <link rel="apple-touch-icon-precomposed" sizes="180x180" href="/apple-touch-icon-v2.png" />
-    <meta name="description" content="Upload bird photos, let AI identify the species, build your BirdDex." />
+    <meta name="description" content="Upload bird photos, let AI identify the species, build your WingDex." />
     <meta name="theme-color" content="#e5ddd0" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="BirdDex" />
-    <meta property="og:title" content="BirdDex" />
-    <meta property="og:description" content="Upload bird photos, let AI identify the species, build your BirdDex." />
+    <meta name="apple-mobile-web-app-title" content="WingDex" />
+    <meta property="og:title" content="WingDex" />
+    <meta property="og:description" content="Upload bird photos, let AI identify the species, build your WingDex." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="/icon-512.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="BirdDex" />
-    <meta name="twitter:description" content="Upload bird photos, let AI identify the species, build your BirdDex." />
+    <meta name="twitter:title" content="WingDex" />
+    <meta name="twitter:description" content="Upload bird photos, let AI identify the species, build your WingDex." />
     <meta name="twitter:image" content="/icon-512.png" />
         <script>
             (() => {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "birddex",
+    "name": "wingdex",
     "private": true,
     "version": "1.3.2",
-    "description": "Photo-first bird identification and BirdDex tracker, built on GitHub Spark",
+    "description": "Photo-first bird identification and WingDex tracker, built on GitHub Spark",
     "repository": {
         "type": "git",
-        "url": "https://github.com/jlian/birddex.git"
+        "url": "https://github.com/jlian/wingdex.git"
     },
     "author": "John Lian",
     "license": "MIT",
@@ -25,7 +25,7 @@
     "scripts": {
         "dev": "vite",
         "kill": "fuser -k 5000/tcp",
-        "setup:playwright": "npx playwright install --with-deps chromium --quiet",
+        "setup:playwright": "npx playwright install --with-deps chromium",
         "build": "tsc -b && vite build",
         "typecheck": "tsc -b",
         "verify": "npm run lint && npm run test:unit && npm run setup:playwright && npm run test:e2e && npm run build",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "BirdDex",
-  "short_name": "BirdDex",
-  "description": "Upload bird photos, let AI identify the species, build your BirdDex.",
+  "name": "WingDex",
+  "short_name": "WingDex",
+  "description": "Upload bird photos, let AI identify the species, build your WingDex.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#f6f1e8",

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "BirdDex",
-  "short_name": "BirdDex",
-  "description": "Upload bird photos, let AI identify the species, build your BirdDex.",
+  "name": "WingDex",
+  "short_name": "WingDex",
+  "description": "Upload bird photos, let AI identify the species, build your WingDex.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#e5ddd0",

--- a/scripts/download-wiki-birds.mjs
+++ b/scripts/download-wiki-birds.mjs
@@ -46,7 +46,7 @@ const OLD_DUPES = [
 ]
 
 const HEADERS = {
-  'User-Agent': 'BirdDexPhotoDownloader/1.0 (https://github.com/jlian/birddex; birddex@example.com)',
+  'User-Agent': 'WingDexPhotoDownloader/1.0 (https://github.com/jlian/wingdex; wingdex@example.com)',
 }
 
 async function getOriginalUrl(filename) {

--- a/scripts/hydrate-wiki-titles.mjs
+++ b/scripts/hydrate-wiki-titles.mjs
@@ -51,7 +51,7 @@ async function fetchWikidataBirds() {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
       'Accept': 'application/sparql-results+json',
-      'User-Agent': 'BirdDex/1.0 (taxonomy hydration; https://github.com/jlian/birddex)',
+      'User-Agent': 'WingDex/1.0 (taxonomy hydration; https://github.com/jlian/wingdex)',
     },
     body: `query=${encodeURIComponent(sparql)}`,
   })
@@ -103,7 +103,7 @@ async function tryWikipediaApi(common, scientific) {
     const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${encoded}`
     try {
       const res = await fetch(url, {
-        headers: { 'Api-User-Agent': 'BirdDex/1.0 (taxonomy hydration)' },
+        headers: { 'Api-User-Agent': 'WingDex/1.0 (taxonomy hydration)' },
       })
       if (res.ok) {
         const data = await res.json()

--- a/scripts/validate-wikipedia.mjs
+++ b/scripts/validate-wikipedia.mjs
@@ -66,7 +66,7 @@ async function fetchWikidataBirds() {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
       'Accept': 'application/sparql-results+json',
-      'User-Agent': 'BirdDex/1.0 (taxonomy validation; https://github.com/jlian/birddex)',
+      'User-Agent': 'WingDex/1.0 (taxonomy validation; https://github.com/jlian/wingdex)',
     },
     body: `query=${encodeURIComponent(sparql)}`,
   })
@@ -184,7 +184,7 @@ async function main() {
       const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${encoded}`
       try {
         const res = await fetch(url, {
-          headers: { 'Api-User-Agent': 'BirdDex/1.0 (taxonomy validation)' },
+          headers: { 'Api-User-Agent': 'WingDex/1.0 (taxonomy validation)' },
         })
         if (res.ok) {
           const data = await res.json()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,12 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import { Toaster } from '@/components/ui/sonner'
 import { MapPin, Bird, GithubLogo } from '@phosphor-icons/react'
-import { useBirdDexData } from '@/hooks/use-birddex-data'
+import { useWingDexData } from '@/hooks/use-wingdex-data'
 import { getStableDevUserId } from '@/lib/dev-user'
 
 import HomePage, { HomeContentSkeleton } from '@/components/pages/HomePage'
 import OutingsPage from '@/components/pages/OutingsPage'
-import BirdDexPage from '@/components/pages/BirdDexPage'
+import WingDexPage from '@/components/pages/WingDexPage'
 import SettingsPage from '@/components/pages/SettingsPage'
 import AddPhotosFlow from '@/components/flows/AddPhotosFlow'
 
@@ -43,7 +43,7 @@ function parseHash(): { tab: string; subId?: string } {
   if (!hash) return { tab: 'home' }
   const [segment, ...rest] = hash.split('/')
   const subId = rest.length > 0 ? decodeURIComponent(rest.join('/')) : undefined
-  if (['home', 'outings', 'birddex', 'settings'].includes(segment)) {
+  if (['home', 'outings', 'wingdex', 'settings'].includes(segment)) {
     return { tab: segment, subId }
   }
   return { tab: 'home' }
@@ -198,7 +198,7 @@ function AuthErrorShell({ message }: { message: string }) {
 function AppContent({ user }: { user: UserInfo }) {
   const { tab, subId, navigate, handleTabChange } = useHashRouter()
   const [showAddPhotos, setShowAddPhotos] = useState(false)
-  const data = useBirdDexData(user.id)
+  const data = useWingDexData(user.id)
   const { resolvedTheme } = useTheme()
 
   // Sync <meta name="theme-color"> with current theme (#17)
@@ -210,7 +210,7 @@ function AppContent({ user }: { user: UserInfo }) {
   }, [resolvedTheme])
 
   const navItems = [
-    { value: 'birddex', label: 'BirdDex', icon: Bird },
+    { value: 'wingdex', label: 'WingDex', icon: Bird },
     { value: 'outings', label: 'Outings', icon: MapPin },
   ]
 
@@ -232,7 +232,7 @@ function AppContent({ user }: { user: UserInfo }) {
                 <Bird size={28} weight="duotone" className="text-primary" />
               </button>
 
-              {/* Nav tabs — BirdDex + Outings (Home via logo, Settings via avatar) */}
+              {/* Nav tabs — WingDex + Outings (Home via logo, Settings via avatar) */}
               <TabsList className="flex bg-transparent gap-1 h-auto p-0">
                 {navItems.map(item => (
                   <TabsTrigger
@@ -276,7 +276,7 @@ function AppContent({ user }: { user: UserInfo }) {
               data={data}
               onAddPhotos={() => setShowAddPhotos(true)}
               onSelectOuting={(id) => navigate('outings', id)}
-              onSelectSpecies={(name) => navigate('birddex', name)}
+              onSelectSpecies={(name) => navigate('wingdex', name)}
               onNavigate={(tab) => navigate(tab)}
             />
           </TabsContent>
@@ -286,15 +286,15 @@ function AppContent({ user }: { user: UserInfo }) {
               data={data}
               selectedOutingId={tab === 'outings' ? (subId ?? null) : null}
               onSelectOuting={(id) => navigate('outings', id ?? undefined)}
-              onSelectSpecies={(name) => navigate('birddex', name)}
+              onSelectSpecies={(name) => navigate('wingdex', name)}
             />
           </TabsContent>
 
-          <TabsContent value="birddex" className="mt-0" forceMount hidden={tab !== 'birddex'}>
-            <BirdDexPage
+          <TabsContent value="wingdex" className="mt-0" forceMount hidden={tab !== 'wingdex'}>
+            <WingDexPage
               data={data}
-              selectedSpecies={tab === 'birddex' ? (subId ?? null) : null}
-              onSelectSpecies={(name) => navigate('birddex', name ?? undefined)}
+              selectedSpecies={tab === 'wingdex' ? (subId ?? null) : null}
+              onSelectSpecies={(name) => navigate('wingdex', name ?? undefined)}
               onSelectOuting={(id) => navigate('outings', id)}
             />
           </TabsContent>
@@ -316,16 +316,16 @@ function AppContent({ user }: { user: UserInfo }) {
       {/* Footer */}
       <div className="flex items-center justify-center gap-3 py-6 text-xs text-muted-foreground/50">
         <span>
-          BirdDex {typeof APP_VERSION !== 'undefined' ? APP_VERSION : 'v1.1.0'} by{' '}
+          WingDex {typeof APP_VERSION !== 'undefined' ? APP_VERSION : 'v1.1.0'} by{' '}
           <a href="https://johnlian.net" target="_blank" rel="noopener noreferrer" className="hover:text-muted-foreground transition-colors">
             John Lian
           </a>
         </span>
         <span>·</span>
-        <a href="https://github.com/jlian/birddex" target="_blank" rel="noopener noreferrer" className="hover:text-muted-foreground transition-colors" aria-label="GitHub">
+        <a href="https://github.com/jlian/wingdex" target="_blank" rel="noopener noreferrer" className="hover:text-muted-foreground transition-colors" aria-label="GitHub">
           <GithubLogo size={14} />
         </a>
-        <a href="https://github.com/jlian/birddex/issues" target="_blank" rel="noopener noreferrer" className="hover:text-muted-foreground transition-colors">
+        <a href="https://github.com/jlian/wingdex/issues" target="_blank" rel="noopener noreferrer" className="hover:text-muted-foreground transition-colors">
           Report Issues
         </a>
       </div>

--- a/src/__tests__/app-auth-guard.hosted.test.tsx
+++ b/src/__tests__/app-auth-guard.hosted.test.tsx
@@ -1,13 +1,13 @@
 /**
  * @vitest-environment jsdom
- * @vitest-environment-options {"url":"https://birddex--jlian.github.app/"}
+ * @vitest-environment-options {"url":"https://wingdex--jlian.github.app/"}
  */
 
 import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/hooks/use-birddex-data', () => ({
-  useBirdDexData: () => ({
+vi.mock('@/hooks/use-wingdex-data', () => ({
+  useWingDexData: () => ({
     photos: [],
     outings: [],
     observations: [],
@@ -50,8 +50,8 @@ vi.mock('@/components/pages/OutingsPage', () => ({
   default: () => <div>OutingsPage</div>,
 }))
 
-vi.mock('@/components/pages/BirdDexPage', () => ({
-  default: () => <div>BirdDexPage</div>,
+vi.mock('@/components/pages/WingDexPage', () => ({
+  default: () => <div>WingDexPage</div>,
 }))
 
 vi.mock('@/components/pages/SettingsPage', () => ({

--- a/src/__tests__/app-auth-guard.local.test.tsx
+++ b/src/__tests__/app-auth-guard.local.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('@/hooks/use-birddex-data', () => ({
-  useBirdDexData: () => ({
+vi.mock('@/hooks/use-wingdex-data', () => ({
+  useWingDexData: () => ({
     photos: [],
     outings: [],
     observations: [],
@@ -45,8 +45,8 @@ vi.mock('@/components/pages/OutingsPage', () => ({
   default: () => <div>OutingsPage</div>,
 }))
 
-vi.mock('@/components/pages/BirdDexPage', () => ({
-  default: () => <div>BirdDexPage</div>,
+vi.mock('@/components/pages/WingDexPage', () => ({
+  default: () => <div>WingDexPage</div>,
 }))
 
 vi.mock('@/components/pages/SettingsPage', () => ({

--- a/src/__tests__/build-dex.test.ts
+++ b/src/__tests__/build-dex.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildDexFromState } from '@/hooks/use-birddex-data'
+import { buildDexFromState } from '@/hooks/use-wingdex-data'
 import type { Outing, Observation, DexEntry } from '@/lib/types'
 
 // ── Helpers ─────────────────────────────────────────────────

--- a/src/__tests__/dev-user-id.test.ts
+++ b/src/__tests__/dev-user-id.test.ts
@@ -14,7 +14,7 @@ function createStorage(initial: Record<string, string> = {}) {
 
 describe('getStableDevUserId', () => {
   test('uses existing persisted ID when valid', () => {
-    const storage = createStorage({ birddex_dev_user_id: '123456789' })
+    const storage = createStorage({ wingdex_dev_user_id: '123456789' })
     const id = getStableDevUserId({ storage, seed: 'example', random: () => 0.42 })
     expect(id).toBe(123456789)
   })
@@ -30,7 +30,7 @@ describe('getStableDevUserId', () => {
   })
 
   test('regenerates when persisted value is invalid', () => {
-    const storage = createStorage({ birddex_dev_user_id: 'not-a-number' })
+    const storage = createStorage({ wingdex_dev_user_id: 'not-a-number' })
     const id = getStableDevUserId({ storage, seed: 'example.com:/birds', random: () => 0.5 })
 
     expect(id).toBeGreaterThanOrEqual(100000000)

--- a/src/__tests__/outings-location-name-edit.test.tsx
+++ b/src/__tests__/outings-location-name-edit.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import OutingsPage from '@/components/pages/OutingsPage'
-import type { BirdDexDataStore } from '@/hooks/use-birddex-data'
+import type { WingDexDataStore } from '@/hooks/use-wingdex-data'
 import type { Outing } from '@/lib/types'
 import { toast } from 'sonner'
 
@@ -25,7 +25,7 @@ const baseOuting: Outing = {
   createdAt: '2026-02-10T21:42:00.000Z',
 }
 
-function createDataStore(): BirdDexDataStore {
+function createDataStore(): WingDexDataStore {
   return {
     isLoading: false,
     photos: [],

--- a/src/__tests__/use-kv.local.test.tsx
+++ b/src/__tests__/use-kv.local.test.tsx
@@ -42,7 +42,7 @@ describe('useKV (local runtime)', () => {
   })
 
   it('initializes from localStorage and does not hit Spark KV', async () => {
-    localStorage.setItem(`birddex_kv_${key}`, JSON.stringify(['saved']))
+    localStorage.setItem(`wingdex_kv_${key}`, JSON.stringify(['saved']))
     const fetchSpy = vi.spyOn(globalThis, 'fetch')
 
     let latest: KVControls<string[]> | null = null
@@ -83,14 +83,14 @@ describe('useKV (local runtime)', () => {
       latest!.setValue(['a', 'b'])
     })
     await waitFor(() => {
-      expect(localStorage.getItem(`birddex_kv_${key}`)).toBe(JSON.stringify(['a', 'b']))
+      expect(localStorage.getItem(`wingdex_kv_${key}`)).toBe(JSON.stringify(['a', 'b']))
     })
 
     act(() => {
       latest!.deleteValue()
     })
     await waitFor(() => {
-      expect(localStorage.getItem(`birddex_kv_${key}`)).toBeNull()
+      expect(localStorage.getItem(`wingdex_kv_${key}`)).toBeNull()
       expect(latest?.value).toEqual([])
       expect(latest?.isLoading).toBe(false)
     })
@@ -115,7 +115,7 @@ describe('useKV (local runtime)', () => {
     act(() => {
       window.dispatchEvent(
         new StorageEvent('storage', {
-          key: `birddex_kv_${key}`,
+          key: `wingdex_kv_${key}`,
           newValue: JSON.stringify(['sync']),
         }),
       )
@@ -139,8 +139,8 @@ describe('useKV (local runtime)', () => {
   })
 
   it('keeps user-scoped keys isolated from each other', async () => {
-    localStorage.setItem('birddex_kv_u1_photos', JSON.stringify(['u1-photo']))
-    localStorage.setItem('birddex_kv_u2_photos', JSON.stringify(['u2-photo']))
+    localStorage.setItem('wingdex_kv_u1_photos', JSON.stringify(['u1-photo']))
+    localStorage.setItem('wingdex_kv_u2_photos', JSON.stringify(['u2-photo']))
 
     let userOne: KVControls<string[]> | null = null
     let userTwo: KVControls<string[]> | null = null
@@ -174,8 +174,8 @@ describe('useKV (local runtime)', () => {
     })
 
     await waitFor(() => {
-      expect(localStorage.getItem('birddex_kv_u1_photos')).toBe(JSON.stringify(['updated-u1']))
-      expect(localStorage.getItem('birddex_kv_u2_photos')).toBe(JSON.stringify(['u2-photo']))
+      expect(localStorage.getItem('wingdex_kv_u1_photos')).toBe(JSON.stringify(['updated-u1']))
+      expect(localStorage.getItem('wingdex_kv_u2_photos')).toBe(JSON.stringify(['u2-photo']))
       expect(userTwo?.value).toEqual(['u2-photo'])
     })
   })

--- a/src/__tests__/use-kv.spark.test.tsx
+++ b/src/__tests__/use-kv.spark.test.tsx
@@ -1,6 +1,6 @@
 /**
  * @vitest-environment jsdom
- * @vitest-environment-options {"url":"https://birddex--jlian.github.app/"}
+ * @vitest-environment-options {"url":"https://wingdex--jlian.github.app/"}
  */
 
 import { render, waitFor } from '@testing-library/react'

--- a/src/assets/manifest.webmanifest
+++ b/src/assets/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "BirdDex",
-  "short_name": "BirdDex",
-  "description": "Upload bird photos, let AI identify the species, build your BirdDex.",
+  "name": "WingDex",
+  "short_name": "WingDex",
+  "description": "Upload bird photos, let AI identify the species, build your WingDex.",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#e5ddd0",

--- a/src/components/flows/AddPhotosFlow.tsx
+++ b/src/components/flows/AddPhotosFlow.tsx
@@ -25,7 +25,7 @@ import { getDisplayName, getScientificName } from '@/lib/utils'
 import { toLocalISOWithOffset } from '@/lib/timezone'
 import ImageCropDialog from '@/components/ui/image-crop-dialog'
 import { Confetti } from '@/components/ui/confetti'
-import type { BirdDexDataStore } from '@/hooks/use-birddex-data'
+import type { WingDexDataStore } from '@/hooks/use-wingdex-data'
 import type { Photo, ObservationStatus } from '@/lib/types'
 import {
   needsCloseConfirmation,
@@ -38,7 +38,7 @@ import type { FlowStep, PhotoResult } from '@/lib/add-photos-helpers'
 import { useBirdImage } from '@/hooks/use-bird-image'
 
 interface AddPhotosFlowProps {
-  data: BirdDexDataStore
+  data: WingDexDataStore
   onClose: () => void
   userId: number
 }
@@ -230,7 +230,7 @@ export default function AddPhotosFlow({ data, onClose, userId }: AddPhotosFlowPr
       if (newSpeciesCount > 0) {
         setShowConfetti(true)
         toast.success(
-          `🎉 ${newSpeciesCount} new species added to your BirdDex!`
+          `🎉 ${newSpeciesCount} new species added to your WingDex!`
         )
         setTimeout(() => setShowConfetti(false), 3500)
       }

--- a/src/components/flows/OutingReview.tsx
+++ b/src/components/flows/OutingReview.tsx
@@ -8,7 +8,7 @@ import { CalendarBlank, CheckCircle, XCircle, PencilSimple, MagnifyingGlass } fr
 import { Switch } from '@/components/ui/switch'
 import { findMatchingOuting } from '@/lib/clustering'
 import { dateToLocalISOWithOffset, toLocalISOWithOffset, formatStoredDate, formatStoredTimeWithTZ } from '@/lib/timezone'
-import type { BirdDexDataStore } from '@/hooks/use-birddex-data'
+import type { WingDexDataStore } from '@/hooks/use-wingdex-data'
 import { toast } from 'sonner'
 
 interface PhotoCluster {
@@ -21,7 +21,7 @@ interface PhotoCluster {
 
 interface OutingReviewProps {
   cluster: PhotoCluster
-  data: BirdDexDataStore
+  data: WingDexDataStore
   userId: number
   /** Pre-fill location from a previous outing (user can override) */
   defaultLocationName?: string

--- a/src/components/pages/HomePage.tsx
+++ b/src/components/pages/HomePage.tsx
@@ -5,10 +5,10 @@ import {
 import { useBirdImage } from '@/hooks/use-bird-image'
 import { getDisplayName } from '@/lib/utils'
 import { formatStoredDate } from '@/lib/timezone'
-import type { BirdDexDataStore } from '@/hooks/use-birddex-data'
+import type { WingDexDataStore } from '@/hooks/use-wingdex-data'
 
 interface HomePageProps {
-  data: BirdDexDataStore
+  data: WingDexDataStore
   onAddPhotos: () => void
   onSelectOuting: (id: string) => void
   onSelectSpecies: (name: string) => void
@@ -101,7 +101,7 @@ export default function HomePage({ data, onAddPhotos, onSelectOuting, onSelectSp
             </h2>
             <p className="text-muted-foreground text-base sm:text-lg leading-relaxed">
               Upload your pics, ID the birds, and build your
-              BirdDex. <em>Reverse birding</em> at its finest.
+              WingDex. <em>Reverse birding</em> at its finest.
             </p>
           </div>
           <Button
@@ -154,7 +154,7 @@ export default function HomePage({ data, onAddPhotos, onSelectOuting, onSelectSp
               </h3>
               {dex.length > 6 && (
                 <button
-                  onClick={() => onNavigate('birddex')}
+                  onClick={() => onNavigate('wingdex')}
                   className="text-xs text-primary hover:text-primary/80 flex items-center gap-1 font-medium transition-colors cursor-pointer"
                 >
                   View all {dex.length}

--- a/src/components/pages/OutingsPage.tsx
+++ b/src/components/pages/OutingsPage.tsx
@@ -30,11 +30,11 @@ import { findBestMatch } from '@/lib/taxonomy'
 import { getDisplayName } from '@/lib/utils'
 import { formatStoredDate, formatStoredTimeWithTZ } from '@/lib/timezone'
 import { toast } from 'sonner'
-import type { BirdDexDataStore } from '@/hooks/use-birddex-data'
+import type { WingDexDataStore } from '@/hooks/use-wingdex-data'
 import type { Outing, Observation } from '@/lib/types'
 
 interface OutingsPageProps {
-  data: BirdDexDataStore
+  data: WingDexDataStore
   selectedOutingId: string | null
   onSelectOuting: (id: string | null) => void
   onSelectSpecies: (name: string) => void
@@ -218,7 +218,7 @@ function OutingDetail({
   onSelectSpecies,
 }: {
   outing: Outing
-  data: BirdDexDataStore
+  data: WingDexDataStore
   onBack: () => void
   onSelectSpecies: (name: string) => void
 }) {
@@ -273,7 +273,7 @@ function OutingDetail({
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `birddex-outing-${new Date(outing.startTime).toISOString().split('T')[0]}.csv`
+    a.download = `wingdex-outing-${new Date(outing.startTime).toISOString().split('T')[0]}.csv`
     a.click()
     URL.revokeObjectURL(url)
     toast.success('Outing exported in eBird Record CSV format')

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -17,10 +17,10 @@ import { textLLM } from '@/lib/ai-inference'
 import { toast } from 'sonner'
 import { parseEBirdCSV, exportDexToCSV, groupPreviewsIntoOutings } from '@/lib/ebird'
 import { SEED_OUTINGS, SEED_OBSERVATIONS, SEED_DEX } from '@/lib/seed-data'
-import type { BirdDexDataStore } from '@/hooks/use-birddex-data'
+import type { WingDexDataStore } from '@/hooks/use-wingdex-data'
 
 interface SettingsPageProps {
-  data: BirdDexDataStore
+  data: WingDexDataStore
   user: {
     id: number
     login: string
@@ -97,10 +97,10 @@ export default function SettingsPage({ data, user }: SettingsPageProps) {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = `birddex-export-${new Date().toISOString().split('T')[0]}.csv`
+    a.download = `wingdex-export-${new Date().toISOString().split('T')[0]}.csv`
     a.click()
     URL.revokeObjectURL(url)
-    toast.success('BirdDex exported')
+    toast.success('WingDex exported')
   }
 
   return (
@@ -147,7 +147,7 @@ export default function SettingsPage({ data, user }: SettingsPageProps) {
         <div className="space-y-2">
           <h3 className="font-semibold text-foreground">Import & Export</h3>
           <p className="text-sm text-muted-foreground">
-            Import your eBird life list or export your BirdDex data
+            Import your eBird life list or export your WingDex data
           </p>
         </div>
 
@@ -233,7 +233,7 @@ export default function SettingsPage({ data, user }: SettingsPageProps) {
             disabled={data.dex.length === 0}
           >
             <Download size={20} className="mr-2" />
-            Export BirdDex
+            Export WingDex
           </Button>
 
           <input
@@ -284,7 +284,7 @@ export default function SettingsPage({ data, user }: SettingsPageProps) {
                 </li>
               </ol>
               <p className="text-xs">
-                BirdDex will create outings grouped by date and location, with all your
+                WingDex will create outings grouped by date and location, with all your
                 species as confirmed observations.
               </p>
             </div>
@@ -340,7 +340,7 @@ export default function SettingsPage({ data, user }: SettingsPageProps) {
                 <AlertDialogTitle>Load demo data?</AlertDialogTitle>
                 <AlertDialogDescription>
                   This will replace all your current outings, observations,
-                  and BirdDex entries with demo data. This action cannot be undone.
+                  and WingDex entries with demo data. This action cannot be undone.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
@@ -372,7 +372,7 @@ export default function SettingsPage({ data, user }: SettingsPageProps) {
                 <AlertDialogTitle>Delete all data?</AlertDialogTitle>
                 <AlertDialogDescription>
                   This will permanently delete all your outings, observations,
-                  and BirdDex entries. This action cannot be undone.
+                  and WingDex entries. This action cannot be undone.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>

--- a/src/components/pages/WingDexPage.tsx
+++ b/src/components/pages/WingDexPage.tsx
@@ -12,20 +12,20 @@ import { EmptyState } from '@/components/ui/empty-state'
 import { getDisplayName, getScientificName } from '@/lib/utils'
 import { getEbirdUrl } from '@/lib/taxonomy'
 import { formatStoredDate } from '@/lib/timezone'
-import type { BirdDexDataStore } from '@/hooks/use-birddex-data'
+import type { WingDexDataStore } from '@/hooks/use-wingdex-data'
 import type { DexEntry, Observation } from '@/lib/types'
 
 type SortField = 'date' | 'count' | 'name'
 type SortDir = 'asc' | 'desc'
 
-interface BirdDexPageProps {
-  data: BirdDexDataStore
+interface WingDexPageProps {
+  data: WingDexDataStore
   selectedSpecies: string | null
   onSelectSpecies: (name: string | null) => void
   onSelectOuting: (id: string) => void
 }
 
-export default function BirdDexPage({ data, selectedSpecies, onSelectSpecies, onSelectOuting }: BirdDexPageProps) {
+export default function WingDexPage({ data, selectedSpecies, onSelectSpecies, onSelectOuting }: WingDexPageProps) {
   const { dex } = data
   const [searchQuery, setSearchQuery] = useState('')
   const [sortField, setSortField] = useState<SortField>('date')
@@ -56,8 +56,8 @@ export default function BirdDexPage({ data, selectedSpecies, onSelectSpecies, on
     return (
       <EmptyState
         icon={Bird}
-        title="Your BirdDex is empty"
-        description="Upload photos and confirm species to start building your BirdDex"
+        title="Your WingDex is empty"
+        description="Upload photos and confirm species to start building your WingDex"
       />
     )
   }
@@ -88,7 +88,7 @@ export default function BirdDexPage({ data, selectedSpecies, onSelectSpecies, on
     <div className="px-4 sm:px-6 py-6 space-y-4 max-w-3xl mx-auto animate-fade-in">
       <div className="space-y-1">
         <h2 className="font-serif text-2xl font-semibold text-foreground">
-          BirdDex
+          WingDex
         </h2>
         <p className="text-sm text-muted-foreground">
           {dex.length} species observed
@@ -159,7 +159,7 @@ function SpeciesDetail({
   onSelectOuting,
 }: {
   entry: DexEntry
-  data: BirdDexDataStore
+  data: WingDexDataStore
   onBack: () => void
   onSelectOuting: (id: string) => void
 }) {

--- a/src/hooks/use-kv.ts
+++ b/src/hooks/use-kv.ts
@@ -8,7 +8,7 @@ import { useState, useCallback, useEffect, useRef } from 'react'
 
 type SetValue<T> = (newValue: T | ((prev: T) => T)) => void
 
-const LS_PREFIX = 'birddex_kv_'
+const LS_PREFIX = 'wingdex_kv_'
 const KV_BASE = '/_spark/kv'
 const SPARK_KV_WRITE_RETRIES = 2
 const USER_SCOPED_KEY_PATTERN = /^u\d+_[a-zA-Z][a-zA-Z0-9_]*$/
@@ -101,6 +101,7 @@ export function useKV<T>(key: string, initialValue: T): [T, SetValue<T>, () => v
   assertUserScopedKey(key)
 
   const sparkRuntime = isSparkHostedRuntime()
+
   const initialValueRef = useRef(initialValue)
   const [value, setValue] = useState<T>(() => (
     sparkRuntime ? initialValue : getLocalStorage(key, initialValue)

--- a/src/hooks/use-wingdex-data.ts
+++ b/src/hooks/use-wingdex-data.ts
@@ -2,7 +2,7 @@ import { useKV } from '@/hooks/use-kv'
 import type { Photo, Outing, Observation, DexEntry } from '@/lib/types'
 import { getUserStorageKey } from '@/lib/storage-keys'
 
-export type BirdDexDataStore = ReturnType<typeof useBirdDexData>
+export type WingDexDataStore = ReturnType<typeof useWingDexData>
 
 export function buildDexFromState(
   allOutings: Outing[],
@@ -63,7 +63,7 @@ export function buildDexFromState(
   return rebuilt.sort((a, b) => a.speciesName.localeCompare(b.speciesName))
 }
 
-export function useBirdDexData(userId: number) {
+export function useWingDexData(userId: number) {
   const [photos, setPhotos, , photosLoading] = useKV<Photo[]>(getUserStorageKey(userId, 'photos'), [])
   const [outings, setOutings, , outingsLoading] = useKV<Outing[]>(getUserStorageKey(userId, 'outings'), [])
   const [observations, setObservations, , observationsLoading] = useKV<Observation[]>(getUserStorageKey(userId, 'observations'), [])

--- a/src/lib/dev-user.ts
+++ b/src/lib/dev-user.ts
@@ -1,4 +1,4 @@
-const DEV_USER_ID_KEY = 'birddex_dev_user_id'
+const DEV_USER_ID_KEY = 'wingdex_dev_user_id'
 
 type StorageLike = Pick<Storage, 'getItem' | 'setItem'>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,7 +39,7 @@ export interface DexEntry {
   speciesName: string
   firstSeenDate: string
   lastSeenDate: string
-  /** When this species was first added to BirdDex (wall-clock time) */
+  /** When this species was first added to WingDex (wall-clock time) */
   addedDate?: string
   totalOutings: number
   totalCount: number

--- a/src/lib/wikimedia.ts
+++ b/src/lib/wikimedia.ts
@@ -39,7 +39,7 @@ async function fetchSummary(title: string): Promise<FetchResult> {
     const encoded = encodeURIComponent(title.replace(/ /g, '_'))
     const res = await fetch(
       `https://en.wikipedia.org/api/rest_v1/page/summary/${encoded}`,
-      { headers: { 'Api-User-Agent': 'BirdDex/1.0 (bird identification app)' } }
+      { headers: { 'Api-User-Agent': 'WingDex/1.0 (bird identification app)' } }
     )
     if (!res.ok) return res.status === 404 ? { kind: 'miss' } : { kind: 'error' }
     const data = (await res.json()) as RestSummary


### PR DESCRIPTION
## Summary
- Rename app and collection naming from **BirdDex** to **WingDex** across UI, routes, symbols, docs, tests, and scripts
- Rename core files:
  - `src/components/pages/BirdDexPage.tsx` -> `src/components/pages/WingDexPage.tsx`
  - `src/hooks/use-birddex-data.ts` -> `src/hooks/use-wingdex-data.ts`
- Update route/tab key from `birddex` to `wingdex`
- Update manifests/meta/title/package metadata to WingDex
- Update exports and copy (`wingdex-export-*`, `wingdex-outing-*`, toasts/labels/text)
- Update repo/app URL references to `jlian/wingdex` and `wingdex--jlian.github.app`
- Simplify storage handling by **not** adding legacy key migration (per decision)
- Fix VS Code verify flow by removing unsupported Playwright `--quiet` flag from `setup:playwright`
- Make `setup-playwright` task quieter using `npm --silent`

## Verification
- `npm run verify`
  - lint ✅
  - unit tests ✅ (22 files, 429 tests)
  - e2e ✅ (32 tests)
  - build ✅

## Next Steps

- [ ] 1. Merge this PR
- [x] 2. Rename the GitHub repository from `jlian/birddex` to `jlian/wingdex` (GitHub redirects old links)
- [ ] 3. Confirm the Spark hosted URL transition is live and accessible
- [ ] 4. Optional: clear old localStorage keys (`birddex_kv_*`, `birddex_dev_user_id`) in existing browsers
- [ ] 5. Optional: if changelog body links should remain historical, keep as-is; if preferred, run a follow-up to align all changelog links to the new slug
