### PR TITLE
ci: use Playwright container image for E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   build-and-test:
     name: Verify & Deploy Preview
     runs-on: ubuntu-latest
+    # Chromium + OS deps pre-installed; update tag when @playwright/test is bumped.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     permissions:
       contents: read
       deployments: write
@@ -36,17 +39,6 @@ jobs:
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright browsers and deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium > /dev/null
 
       - name: Lint
         run: npm run lint

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,9 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
+    // --ip 127.0.0.1 works around wrangler hanging in Docker (cloudflare/workers-sdk#6280)
     command: isCI
-      ? 'npx wrangler pages dev dist --port 5000 --show-interactive-dev-session=false'
+      ? 'npx wrangler pages dev dist --port 5000 --ip 127.0.0.1 --show-interactive-dev-session=false'
       : 'npm run dev:full:restart',
     url: 'http://localhost:5000',
     reuseExistingServer: !isCI,


### PR DESCRIPTION
## Summary

Switch CI E2E from bare-metal Playwright install to the official
`mcr.microsoft.com/playwright:v1.58.2-noble` container image, eliminating the
browser-cache and install-deps steps entirely.

Closes #197

## Changes

- **ci.yml**: add `container: image: mcr.microsoft.com/playwright:v1.58.2-noble`,
  remove `Cache Playwright browsers` and `Install Playwright browsers and deps` steps
- **playwright.config.ts**: add `--ip 127.0.0.1` to the CI wrangler command to
  work around cloudflare/workers-sdk#6280 (wrangler hangs in Docker when binding
  to IPv6 `::1`)

## Root cause - wrangler hang in Docker

`wrangler pages dev` binds to `::1` (IPv6 localhost) by default. Docker containers
typically lack an IPv6 loopback interface, so the server starts but nothing can
connect. Adding `--ip 127.0.0.1` forces IPv4 binding.

Reference: https://github.com/cloudflare/workers-sdk/issues/6280

## Timing comparison (single run, cold caches)

| Step | Bare metal | Container | Delta |
|---|---|---|---|
| Set up job | 1s | 2s | +1s |
| Initialize containers | -- | 25s | +25s |
| Checkout | 2s | 4s | +2s |
| Setup Node | 6s | 6s | 0 |
| Cache node_modules | 0s | 0s | 0 |
| Install dependencies | 14s | 15s | +1s |
| Cache Playwright browsers | 1s | -- | -1s |
| Install Playwright + deps | 29s | -- | -29s |
| Lint | 7s | 8s | +1s |
| Typecheck | 7s | 6s | -1s |
| Unit tests | 13s | 15s | +2s |
| Build | 12s | 12s | 0 |
| Migrate local D1 | 3s | 3s | 0 |
| E2E tests | 59s | 56s | -3s |
| Deploy preview | 22s | 21s | -1s |
| **Total wall clock** | **3m 03s** | **3m 22s** | **+19s** |

The +19s delta is inflated by first-run cache-save overhead (28s vs 7s for
`Post Cache node_modules`). Steady-state comparison: container init (25s) vs
Playwright install (29s on cold cache, 0s on warm cache). Net is roughly even
on cold caches and ~25s slower on warm caches.

## Why this is still worth it

1. **Reliability**: the old approach skipped `install --with-deps` on cache hit,
   silently depending on the runner image having the right shared libraries.
   Runner image updates could break E2E without any code change.
2. **Determinism**: container pins the exact Chromium version and OS deps.
   No variance from runner image updates.
3. **Simplicity**: two fewer cache/install steps to maintain. Updating Playwright
   just means bumping the container tag.

## Validation

- 1 passing CI run so far (run 22372085943)
- Issue #197 asks for 5 runs; additional runs will accumulate as the PR collects
  review iterations or can be triggered manually
