### PR TITLE
chore(Node): downgrade from Node 25 to Node 24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 24
 
       - name: Cache node_modules
         id: node-modules-cache

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/rehydrate-wiki-taxonomy.yml
+++ b/.github/workflows/rehydrate-wiki-taxonomy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/rotate-apple-secret.yml
+++ b/.github/workflows/rotate-apple-secret.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 24
 
       - name: Install wrangler
         run: npm install -g wrangler

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for your interest in contributing! Here's how to get started.
    npm ci
    ```
 
-   Use Node 25+ (`node --version`).
+   Use Node 24+ (`node --version`).
 
 2. **Start the dev server**
    ```bash

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ WingDex is for **reverse birding**: people who take photos first and identify sp
 
 ### Prerequisites
 
-Use Node 25+ (`node --version`) and install dependencies with `npm ci`.
+Use Node 24+ (`node --version`) and install dependencies with `npm ci`.
 
 ### Running locally
 

--- a/docs/MIGRATION_PLAN_TRACKER.md
+++ b/docs/MIGRATION_PLAN_TRACKER.md
@@ -990,7 +990,7 @@ on:
 jobs:
   build-and-test:
     steps:
-      - Checkout, setup Node 25, npm ci
+      - Checkout, setup Node 24, npm ci
       - Lint
       - Typecheck
       - Unit tests
@@ -1012,7 +1012,7 @@ concurrency:
 jobs:
   release:
     steps:
-      - Checkout, setup Node 25, npm ci
+      - Checkout, setup Node 24, npm ci
       - Build
       - Semantic-release (main only)
       - Ensure BETTER_AUTH_SECRET in Pages

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ],
     "type": "module",
     "engines": {
-        "node": ">=25.0.0"
+        "node": ">=24.0.0"
     },
     "scripts": {
         "dev": "bash scripts/dev.sh",


### PR DESCRIPTION
## Summary

Downgrade from Node 25 (Current) to Node 24 (active LTS) for longer support and stability. No Node 25-specific APIs are used in this project - the actual runtime is Cloudflare Workers (V8-based), and `@types/node` was already on `^22`.

## Changes

- `package.json` engines: `>=25.0.0` -> `>=24.0.0`
- All 5 CI workflows: `node-version: 25` -> `24`
- Fixed stale step name in `copilot-setup-steps.yml` (said "Node.js 22")
- Updated `README.md`, `CONTRIBUTING.md`, and `MIGRATION_PLAN_TRACKER.md`

## Verification

- All 571 unit tests pass locally
- CI will validate on this PR
