### PR TITLE
perf(BirdID): off-main-thread photo decoding; fix(RangeFilter): soften out-of-range penalty

### DIFF
--- a/functions/lib/range-adjust.js
+++ b/functions/lib/range-adjust.js
@@ -97,7 +97,7 @@ export function parseCellBlob(data, wanted) {
 // ── Tiered confidence adjustment ────────────────────────────
 //
 // Four layers of multipliers, applied multiplicatively:
-//   1. Base: status (present=1.0, near-range=0.85, out-of-range=0.5)
+//   1. Base: status (present=1.0, near-range=0.85, out-of-range=0.65)
 //   2. Presence quality (Extant=1.0, Possibly Extant=0.95, etc.)
 //   3. Origin type (Native=1.0, Vagrant=0.85, etc.)
 //   4. Seasonal match (in-season=1.0, out-of-season=0.9)

--- a/functions/lib/range-adjust.js
+++ b/functions/lib/range-adjust.js
@@ -105,7 +105,7 @@ export function parseCellBlob(data, wanted) {
 // Layers 2-4 only apply when status is 'present' or 'near-range'.
 
 export const NEAR_RANGE_TRUST = 0.85
-export const OUT_OF_RANGE_TRUST = 0.5
+export const OUT_OF_RANGE_TRUST = 0.65
 
 export function presenceTrust(presence) {
   switch (presence) {

--- a/ios/WingDex/ViewModels/AddPhotosViewModel.swift
+++ b/ios/WingDex/ViewModels/AddPhotosViewModel.swift
@@ -792,7 +792,7 @@ struct IdentifiedCandidate {
 }
 
 /// AI crop box in percentage coordinates (0-100).
-struct CropBoxResult {
+struct CropBoxResult: Sendable {
     let x: Double
     let y: Double
     let width: Double

--- a/ios/WingDex/Views/AddPhotosFlow/PerPhotoConfirmView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/PerPhotoConfirmView.swift
@@ -21,6 +21,9 @@ struct PerPhotoConfirmView: View {
     @State private var galleryPlumages: [String?] = []
     @State private var galleryTask: Task<Void, Never>?
     @State private var galleryIndex = 0
+    @State private var decodedCroppedImage: UIImage?
+    @State private var decodedThumbnail: UIImage?
+    @State private var cachedGalleryItems: [(url: URL, plumage: String?)] = []
 
     private var photo: ProcessedPhoto? { viewModel.currentPhoto }
     private var candidates: [IdentifiedCandidate] { viewModel.currentCandidates }
@@ -114,6 +117,8 @@ struct PerPhotoConfirmView: View {
         .onAppear { initializeSelection() }
         .onChange(of: viewModel.currentPhotoIndex) { initializeSelection() }
         .onChange(of: viewModel.currentCandidates.count) { initializeSelection() }
+        .onChange(of: wikiImageURL) { recomputeGalleryItems() }
+        .onChange(of: galleryURLs) { recomputeGalleryItems() }
     }
 
     // MARK: - No Candidates
@@ -122,7 +127,7 @@ struct PerPhotoConfirmView: View {
         VStack(spacing: 24) {
             Spacer()
 
-            if let photo, let uiImage = UIImage(data: photo.thumbnail) {
+            if let uiImage = decodedThumbnail {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFit()
@@ -197,16 +202,8 @@ struct PerPhotoConfirmView: View {
 
     private func aiCroppedUserPhoto(size: CGFloat) -> some View {
         Group {
-            if let croppedData = photo?.croppedImage,
-               let croppedImage = UIImage(data: croppedData) {
-                Image(uiImage: croppedImage)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: size, height: size)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-            } else if let photo, let cropBox = photo.aiCropBox,
-                      let previewImage = aiPreviewImage(from: photo.image, cropBox: cropBox) {
-                Image(uiImage: previewImage)
+            if let img = decodedCroppedImage {
+                Image(uiImage: img)
                     .resizable()
                     .scaledToFill()
                     .frame(width: size, height: size)
@@ -217,7 +214,7 @@ struct PerPhotoConfirmView: View {
         }
     }
 
-    private func aiPreviewImage(from imageData: Data, cropBox: CropBoxResult) -> UIImage? {
+    private nonisolated static func aiPreviewImage(from imageData: Data, cropBox: CropBoxResult) -> UIImage? {
         guard let uiImage = UIImage(data: imageData) else { return nil }
         let uprightImage = uiImage.imageOrientation == .up
             ? uiImage
@@ -244,7 +241,7 @@ struct PerPhotoConfirmView: View {
 
     private func fallbackPhoto(size: CGFloat) -> some View {
         Group {
-            if let photo, let uiImage = UIImage(data: photo.thumbnail) {
+            if let uiImage = decodedThumbnail {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFill()
@@ -266,7 +263,7 @@ struct PerPhotoConfirmView: View {
     // MARK: - Wiki Square Thumbnail (portrait-aware, swipeable gallery)
 
     /// All gallery items (URL + plumage), with plumage-matching images promoted to the front.
-    private var sortedGalleryItems: [(url: URL, plumage: String?)] {
+    private func computeSortedGalleryItems() -> [(url: URL, plumage: String?)] {
         var items: [(url: URL, plumage: String?)] = []
         var idx = 0
         if let u = wikiImageURL {
@@ -293,11 +290,11 @@ struct PerPhotoConfirmView: View {
         return matching + rest
     }
 
-    private var allWikiURLs: [URL] { sortedGalleryItems.map(\.url) }
+    private var allWikiURLs: [URL] { cachedGalleryItems.map(\.url) }
 
     /// Label for the current gallery image, including plumage if available.
     private var currentRefLabel: String {
-        let items = sortedGalleryItems
+        let items = cachedGalleryItems
         guard !items.isEmpty else { return "Reference" }
         let idx = min(galleryIndex, items.count - 1)
         if idx >= 0, let plumage = items[idx].plumage {
@@ -456,6 +453,7 @@ struct PerPhotoConfirmView: View {
             selectedSpecies = top.species
             selectedConfidence = top.confidence
         } else { selectedSpecies = ""; selectedConfidence = 0 }
+        decodeUserImages()
         fetchWikiImage()
     }
 
@@ -463,6 +461,34 @@ struct PerPhotoConfirmView: View {
         selectedSpecies = candidate.species
         selectedConfidence = candidate.confidence
         fetchWikiImage()
+        recomputeGalleryItems()
+    }
+
+    /// Decode user photo images off the main thread so the view body never calls UIImage(data:).
+    private func decodeUserImages() {
+        let currentPhoto = photo
+        decodedCroppedImage = nil
+        decodedThumbnail = nil
+        Task.detached(priority: .userInitiated) {
+            var cropped: UIImage?
+            var thumb: UIImage?
+            if let data = currentPhoto?.croppedImage {
+                cropped = UIImage(data: data)
+            } else if let p = currentPhoto, let box = p.aiCropBox {
+                cropped = Self.aiPreviewImage(from: p.image, cropBox: box)
+            }
+            if let data = currentPhoto?.thumbnail {
+                thumb = UIImage(data: data)
+            }
+            await MainActor.run {
+                decodedCroppedImage = cropped
+                decodedThumbnail = thumb
+            }
+        }
+    }
+
+    private func recomputeGalleryItems() {
+        cachedGalleryItems = computeSortedGalleryItems()
     }
 
     private func confirmWith(status: ObservationStatus) {

--- a/ios/WingDex/Views/AddPhotosFlow/PerPhotoConfirmView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/PerPhotoConfirmView.swift
@@ -115,6 +115,10 @@ struct PerPhotoConfirmView: View {
         .onAppear { initializeSelection() }
         .onChange(of: viewModel.currentPhotoIndex) { initializeSelection() }
         .onChange(of: viewModel.currentCandidates.count) { initializeSelection() }
+        .onDisappear {
+            decodeTask?.cancel()
+            galleryTask?.cancel()
+        }
     }
 
     // MARK: - No Candidates
@@ -449,31 +453,53 @@ struct PerPhotoConfirmView: View {
     }
 
     /// Decode user photo images off the main thread so the view body never calls UIImage(data:).
+    /// Captures only Sendable values (Data, CropBoxResult, String) into the detached task.
     private func decodeUserImages() {
         decodeTask?.cancel()
-        let currentPhoto = photo
-        let photoId = currentPhoto?.id
         decodedCroppedImage = nil
         decodedThumbnail = nil
+        guard let currentPhoto = photo else { return }
+        let photoId = currentPhoto.id
+        let croppedData = currentPhoto.croppedImage
+        let fullData = currentPhoto.image
+        let cropBox = currentPhoto.aiCropBox
+        let thumbData = currentPhoto.thumbnail
         decodeTask = Task.detached(priority: .userInitiated) {
-            var cropped: UIImage?
-            var thumb: UIImage?
-            if let data = currentPhoto?.croppedImage {
-                cropped = UIImage(data: data)
-            } else if let p = currentPhoto, let box = p.aiCropBox {
-                cropped = Self.aiPreviewImage(from: p.image, cropBox: box)
-            }
-            guard !Task.isCancelled else { return }
-            if let data = currentPhoto?.thumbnail {
-                thumb = UIImage(data: data)
-            }
+            let decoded = Self.decodeImages(
+                croppedData: croppedData,
+                fullData: fullData,
+                cropBox: cropBox,
+                thumbData: thumbData
+            )
             guard !Task.isCancelled else { return }
             await MainActor.run {
                 guard photo?.id == photoId else { return }
-                decodedCroppedImage = cropped
-                decodedThumbnail = thumb
+                decodedCroppedImage = decoded.cropped
+                decodedThumbnail = decoded.thumb
             }
         }
+    }
+
+    /// Sendable wrapper for the decoded UIImages crossing the actor boundary.
+    private struct DecodedImages: @unchecked Sendable {
+        let cropped: UIImage?
+        let thumb: UIImage?
+    }
+
+    private nonisolated static func decodeImages(
+        croppedData: Data?,
+        fullData: Data,
+        cropBox: CropBoxResult?,
+        thumbData: Data
+    ) -> DecodedImages {
+        var cropped: UIImage?
+        if let data = croppedData {
+            cropped = UIImage(data: data)
+        } else if let box = cropBox {
+            cropped = aiPreviewImage(from: fullData, cropBox: box)
+        }
+        let thumb = UIImage(data: thumbData)
+        return DecodedImages(cropped: cropped, thumb: thumb)
     }
 
     private func confirmWith(status: ObservationStatus) {

--- a/ios/WingDex/Views/AddPhotosFlow/PerPhotoConfirmView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/PerPhotoConfirmView.swift
@@ -589,7 +589,7 @@ struct PerPhotoConfirmView: View {
             #if DEBUG
             print("[Wiki] After filtering: \(urls.count) URLs")
             #endif
-            let items = zip(urls, plumages).map { (url: $0, plumage: $1) }
+            let items = zip(urls, plumages).map { (url, plumage) in (url: url, plumage: plumage) }
             await MainActor.run {
                 galleryItems = sortedByPlumage(items)
                 isLoadingWikiImage = false

--- a/ios/WingDex/Views/AddPhotosFlow/PerPhotoConfirmView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/PerPhotoConfirmView.swift
@@ -15,15 +15,13 @@ struct PerPhotoConfirmView: View {
 
     @State private var selectedSpecies = ""
     @State private var selectedConfidence: Double = 0
-    @State private var wikiImageURL: URL?
     @State private var isLoadingWikiImage = false
-    @State private var galleryURLs: [URL] = []
-    @State private var galleryPlumages: [String?] = []
+    @State private var galleryItems: [(url: URL, plumage: String?)] = []
     @State private var galleryTask: Task<Void, Never>?
     @State private var galleryIndex = 0
     @State private var decodedCroppedImage: UIImage?
     @State private var decodedThumbnail: UIImage?
-    @State private var cachedGalleryItems: [(url: URL, plumage: String?)] = []
+    @State private var decodeTask: Task<Void, Never>?
 
     private var photo: ProcessedPhoto? { viewModel.currentPhoto }
     private var candidates: [IdentifiedCandidate] { viewModel.currentCandidates }
@@ -117,8 +115,6 @@ struct PerPhotoConfirmView: View {
         .onAppear { initializeSelection() }
         .onChange(of: viewModel.currentPhotoIndex) { initializeSelection() }
         .onChange(of: viewModel.currentCandidates.count) { initializeSelection() }
-        .onChange(of: wikiImageURL) { recomputeGalleryItems() }
-        .onChange(of: galleryURLs) { recomputeGalleryItems() }
     }
 
     // MARK: - No Candidates
@@ -262,19 +258,8 @@ struct PerPhotoConfirmView: View {
 
     // MARK: - Wiki Square Thumbnail (portrait-aware, swipeable gallery)
 
-    /// All gallery items (URL + plumage), with plumage-matching images promoted to the front.
-    private func computeSortedGalleryItems() -> [(url: URL, plumage: String?)] {
-        var items: [(url: URL, plumage: String?)] = []
-        var idx = 0
-        if let u = wikiImageURL {
-            items.append((u, galleryPlumages.indices.contains(idx) ? galleryPlumages[idx] : nil))
-            idx += 1
-        }
-        for u in galleryURLs {
-            items.append((u, galleryPlumages.indices.contains(idx) ? galleryPlumages[idx] : nil))
-            idx += 1
-        }
-        // Promote images whose plumage matches the LLM-detected plumage
+    /// Reorder gallery items so plumage-matching images come first.
+    private func sortedByPlumage(_ items: [(url: URL, plumage: String?)]) -> [(url: URL, plumage: String?)] {
         guard let detected = selectedPlumage?.lowercased(), !detected.isEmpty else { return items }
         let detectedTags = Set(detected.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) })
         let matching = items.filter { item in
@@ -290,11 +275,11 @@ struct PerPhotoConfirmView: View {
         return matching + rest
     }
 
-    private var allWikiURLs: [URL] { cachedGalleryItems.map(\.url) }
+    private var allWikiURLs: [URL] { galleryItems.map(\.url) }
 
     /// Label for the current gallery image, including plumage if available.
     private var currentRefLabel: String {
-        let items = cachedGalleryItems
+        let items = galleryItems
         guard !items.isEmpty else { return "Reference" }
         let idx = min(galleryIndex, items.count - 1)
         if idx >= 0, let plumage = items[idx].plumage {
@@ -461,15 +446,16 @@ struct PerPhotoConfirmView: View {
         selectedSpecies = candidate.species
         selectedConfidence = candidate.confidence
         fetchWikiImage()
-        recomputeGalleryItems()
     }
 
     /// Decode user photo images off the main thread so the view body never calls UIImage(data:).
     private func decodeUserImages() {
+        decodeTask?.cancel()
         let currentPhoto = photo
+        let photoId = currentPhoto?.id
         decodedCroppedImage = nil
         decodedThumbnail = nil
-        Task.detached(priority: .userInitiated) {
+        decodeTask = Task.detached(priority: .userInitiated) {
             var cropped: UIImage?
             var thumb: UIImage?
             if let data = currentPhoto?.croppedImage {
@@ -477,18 +463,17 @@ struct PerPhotoConfirmView: View {
             } else if let p = currentPhoto, let box = p.aiCropBox {
                 cropped = Self.aiPreviewImage(from: p.image, cropBox: box)
             }
+            guard !Task.isCancelled else { return }
             if let data = currentPhoto?.thumbnail {
                 thumb = UIImage(data: data)
             }
+            guard !Task.isCancelled else { return }
             await MainActor.run {
+                guard photo?.id == photoId else { return }
                 decodedCroppedImage = cropped
                 decodedThumbnail = thumb
             }
         }
-    }
-
-    private func recomputeGalleryItems() {
-        cachedGalleryItems = computeSortedGalleryItems()
     }
 
     private func confirmWith(status: ObservationStatus) {
@@ -499,11 +484,11 @@ struct PerPhotoConfirmView: View {
         galleryTask?.cancel()
         galleryIndex = 0
         let species = selectedSpecies
-        guard !species.isEmpty else { wikiImageURL = nil; galleryURLs = []; galleryPlumages = []; galleryIndex = 0; return }
+        guard !species.isEmpty else { galleryItems = []; galleryIndex = 0; return }
 
         let displayName = getDisplayName(species)
-        isLoadingWikiImage = true; wikiImageURL = nil
-        galleryURLs = []; galleryPlumages = []
+        isLoadingWikiImage = true
+        galleryItems = []
 
         // Single Wikimedia Commons search: returns thumbnails + descriptions in one call
         galleryTask = Task { await performCommonsGalleryFetch(displayName: displayName) }
@@ -604,10 +589,9 @@ struct PerPhotoConfirmView: View {
             #if DEBUG
             print("[Wiki] After filtering: \(urls.count) URLs")
             #endif
+            let items = zip(urls, plumages).map { (url: $0, plumage: $1) }
             await MainActor.run {
-                wikiImageURL = urls.first
-                galleryURLs = Array(urls.dropFirst())
-                galleryPlumages = plumages
+                galleryItems = sortedByPlumage(items)
                 isLoadingWikiImage = false
             }
         } catch is CancellationError { /* expected */ }

--- a/src/__tests__/range-filter.test.ts
+++ b/src/__tests__/range-filter.test.ts
@@ -49,7 +49,7 @@ describe('adjustConfidence', () => {
   })
 
   it('moderate penalty when out of range', () => {
-    expect(adjustConfidence(0.80, { status: 'out-of-range' })).toBeCloseTo(0.40)
+    expect(adjustConfidence(0.80, { status: 'out-of-range' })).toBeCloseTo(0.52)
   })
 
   it('near-range applies 0.85x base penalty', () => {


### PR DESCRIPTION
## Summary

Two areas of improvement: BirdID photo decoding performance on iOS, and range-filter penalty tuning.

## Changes

### perf(BirdID): decode user photos off main thread to fix scroll lag

Moves photo decoding off the main thread so the gallery does not stutter during the Add Photos flow.

### fix(BirdID): address review - cancel stale decode tasks, simplify gallery state

Follow-up cleanup: cancels in-flight decode tasks when new photos are selected and simplifies gallery state management.

### fix(BirdID): use explicit tuple destructuring in zip map

Minor Swift fix for clearer tuple destructuring in the zip map.

### fix(RangeFilter): soften out-of-range penalty for BirdLife data gaps

Raises `OUT_OF_RANGE_TRUST` from 0.5 to 0.65 to reduce over-penalization caused by gaps in BirdLife International range data. Yellow-crowned Night Heron (ycnher) is a known resident in San Diego, but BirdLife data does not include the species anywhere near that area (nearest cell is in coastal Texas). The previous 0.5x penalty halved the LLM confidence for a correct identification.

Closes #242
