### PR TITLE
fix: Settings page UX and location search improvements

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -82,8 +82,7 @@ test.describe('App smoke tests', () => {
     // Settings page should show expected sections
     await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Import & Export' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Data Storage & Privacy' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Data Management' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Account Management' })).toBeVisible();
 
     // Filter out known non-critical errors
     const criticalErrors = errors.filter(

--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -165,10 +165,10 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       addTraceHeaders(response, traceCtx)
       // Suppress completion log for /api/health (internal infra polling, not user-triggered)
       if (pathname !== '/api/health') {
-        emitCompletionLog(log, op, response.status, Date.now() - start, method, pathname)
+        context.waitUntil(emitCompletionLog(log, op, response, Date.now() - start, method, pathname))
       } else if (!response.ok) {
         // Always log health failures
-        emitCompletionLog(log, op, response.status, Date.now() - start, method, pathname)
+        context.waitUntil(emitCompletionLog(log, op, response, Date.now() - start, method, pathname))
       }
       return response
     } catch (err) {
@@ -215,7 +215,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   try {
     const response = withSecurityHeaders(await context.next())
     addTraceHeaders(response, traceCtx)
-    emitCompletionLog(log, op, response.status, Date.now() - start, method, pathname)
+    context.waitUntil(emitCompletionLog(log, op, response, Date.now() - start, method, pathname))
     return response
   } catch (err) {
     return handleUnexpectedError(err, log, traceCtx, op, start)
@@ -223,9 +223,34 @@ export const onRequest: PagesFunction<Env> = async (context) => {
 }
 
 /** Emit the single request-lifecycle completion log with dynamic level. */
-function emitCompletionLog(log: ReturnType<typeof createLogger>, op: string, status: number, durationMs: number, method: string, pathname: string): void {
+async function emitCompletionLog(log: ReturnType<typeof createLogger>, op: string, response: Response, durationMs: number, method: string, pathname: string): Promise<void> {
+  const status = response.status
+  // For error responses, try to extract a meaningful description from the body
+  let description = `HTTP ${status}`
+  if (status >= 400) {
+    try {
+      const contentType = response.headers.get('content-type') || ''
+      const contentLength = parseInt(response.headers.get('content-length') || '', 10)
+      // Only read small text/json bodies with a known size to avoid logging large or binary payloads
+      if ((contentType.includes('json') || contentType.includes('text')) && !isNaN(contentLength) && contentLength <= 4096) {
+        const cloned = response.clone()
+        const body = await cloned.text()
+        if (body) {
+          try {
+            const json = JSON.parse(body) as Record<string, unknown>
+            const msg = json.message || json.error || json.detail
+            if (typeof msg === 'string') description = msg.slice(0, 200)
+          } catch {
+            if (body.length <= 200) description = body
+          }
+        }
+      }
+    } catch {
+      // Ignore read failures; keep default description
+    }
+  }
   const resultType = status < 400 ? 'Succeeded' : 'Failed'
-  const fields = { category: 'Request' as const, resultType: resultType as 'Succeeded' | 'Failed', resultSignature: status, resultDescription: `HTTP ${status}`, durationMs, properties: { 'http.method': method, 'http.route': pathname } }
+  const fields = { category: 'Request' as const, resultType: resultType as 'Succeeded' | 'Failed', resultSignature: status, resultDescription: description, durationMs, properties: { 'http.method': method, 'http.route': pathname } }
   if (status >= 500) {
     log.error(op, fields)
   } else if (status >= 400) {

--- a/functions/lib/auth.ts
+++ b/functions/lib/auth.ts
@@ -114,7 +114,7 @@ export function createAuth(env: Env, options: CreateAuthOptions = {}) {
 
   const inferredLocalAppOrigin = (() => {
     if (!requestOrigin || !requestUrl) return null
-    const isWranglerApiOrigin = isLoopbackOrigin(requestOrigin) && requestUrl.port === '8788'
+    const isWranglerApiOrigin = isLoopbackOrigin(requestOrigin) && requestUrl.port !== '5000'
     if (!isWranglerApiOrigin) return null
 
     if (headerOrigin && isLoopbackOrigin(headerOrigin)) {

--- a/src/components/flows/OutingReview.tsx
+++ b/src/components/flows/OutingReview.tsx
@@ -1,10 +1,9 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { OutingNameAutocomplete } from '@/components/ui/outing-name-autocomplete'
-import { CalendarBlank, CheckCircle, XCircle, PencilSimple, MagnifyingGlass } from '@phosphor-icons/react'
+import { CalendarBlank, CheckCircle, XCircle, PencilSimple } from '@phosphor-icons/react'
 import { Switch } from '@/components/ui/switch'
 import { findMatchingOuting } from '@/lib/clustering'
 import { dateToLocalISOWithOffset, toLocalISOWithOffset, formatStoredDate, formatStoredTimeWithTZ } from '@/lib/timezone'
@@ -103,10 +102,11 @@ export default function OutingReview({
   const [overriddenStartTime, setOverriddenStartTime] = useState<Date | null>(null)
 
   // Place search (#13)
-  const [placeQuery, setPlaceQuery] = useState('')
-  const [placeResults, setPlaceResults] = useState<Array<{ display_name: string; lat: string; lon: string; address?: Record<string, string> }>>([])
+  const [placeResults, setPlaceResults] = useState<Array<{ place_id: number; display_name: string; lat: string; lon: string; address?: Record<string, string> }>>([])
   const [isSearchingPlace, setIsSearchingPlace] = useState(false)
   const [overriddenCoords, setOverriddenCoords] = useState<{ lat: number; lon: number } | null>(null)
+  const [isEditingLocation, setIsEditingLocation] = useState(false)
+  const [locationSearchQuery, setLocationSearchQuery] = useState('')
 
   // Effective coordinates (manual override or cluster GPS)
   const effectiveLat = overriddenCoords?.lat ?? cluster.centerLat
@@ -379,42 +379,67 @@ export default function OutingReview({
     }
   }
 
-  const searchPlace = async () => {
-    if (!placeQuery.trim()) return
+  const searchAbortRef = useRef<AbortController | null>(null)
+
+  const searchPlace = useCallback(async (query: string) => {
+    if (!query.trim()) return
+    searchAbortRef.current?.abort()
+    const controller = new AbortController()
+    searchAbortRef.current = controller
     setIsSearchingPlace(true)
     try {
       const url = new URL('https://nominatim.openstreetmap.org/search')
       url.searchParams.set('format', 'jsonv2')
-      url.searchParams.set('q', placeQuery)
+      url.searchParams.set('q', query)
       url.searchParams.set('limit', '5')
       url.searchParams.set('addressdetails', '1')
       url.searchParams.set('accept-language', 'en')
-      const res = await fetch(url.toString())
+      const res = await fetch(url.toString(), { signal: controller.signal })
       if (!res.ok) throw new Error(`Nominatim ${res.status}`)
       const results = await res.json()
-      setPlaceResults(results)
+      if (!controller.signal.aborted) setPlaceResults(results)
     } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') return
       if (import.meta.env.DEV) console.error('Place search failed:', error)
       toast.error('Place search failed')
     } finally {
-      setIsSearchingPlace(false)
+      if (!controller.signal.aborted) setIsSearchingPlace(false)
     }
-  }
+  }, [])
 
-  const selectPlace = (place: { display_name: string; lat: string; lon: string; address?: Record<string, string> }) => {
+  const selectPlace = (place: { place_id: number; display_name: string; lat: string; lon: string; address?: Record<string, string> }) => {
+    searchAbortRef.current?.abort()
+    setIsSearchingPlace(false)
     const lat = parseFloat(place.lat)
     const lon = parseFloat(place.lon)
     setOverriddenCoords({ lat, lon })
     // Use the first part of the display name as location name
     const shortName = place.display_name.split(',').slice(0, 3).join(',').trim()
     setLocationName(shortName)
-    setSuggestedLocation(shortName)
     const region = extractRegionCodes(place)
     setInferredStateProvince(region.stateProvince)
     setInferredCountryCode(region.countryCode)
     setPlaceResults([])
-    setPlaceQuery('')
+    setIsEditingLocation(false)
+    setLocationSearchQuery('')
   }
+
+  // Debounced place search: trigger Nominatim when user types in search field
+  useEffect(() => {
+    if (!locationSearchQuery.trim() || locationSearchQuery.trim().length < 3) {
+      searchAbortRef.current?.abort()
+      setIsSearchingPlace(false)
+      setPlaceResults([])
+      return
+    }
+    const timer = setTimeout(() => {
+      void searchPlace(locationSearchQuery)
+    }, 500)
+    return () => {
+      clearTimeout(timer)
+      searchAbortRef.current?.abort()
+    }
+  }, [locationSearchQuery, searchPlace])
 
 
   return (
@@ -520,67 +545,83 @@ export default function OutingReview({
                 <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
                 <span>Identifying location from GPS...</span>
               </div>
-            ) : (
-              <>
-                <OutingNameAutocomplete
+            ) : isEditingLocation ? (
+              <div className="relative space-y-2">
+                <Input
                   id="location-name"
-                  value={locationName}
-                  onChange={setLocationName}
-                  outings={data.outings}
-                  placeholder="e.g., Central Park, NYC"
+                  autoFocus
+                  placeholder="Search for a place..."
+                  value={locationSearchQuery}
+                  onChange={e => setLocationSearchQuery(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' && locationSearchQuery.trim()) {
+                      setLocationName(locationSearchQuery.trim())
+                      setOverriddenCoords(null)
+                      setInferredStateProvince(undefined)
+                      setInferredCountryCode(undefined)
+                      setIsEditingLocation(false)
+                      setLocationSearchQuery('')
+                      setPlaceResults([])
+                    }
+                    if (e.key === 'Escape') {
+                      setIsEditingLocation(false)
+                      setLocationSearchQuery('')
+                      setPlaceResults([])
+                    }
+                  }}
                 />
-                {suggestedLocation && (
-                  <p className="text-xs text-muted-foreground">
-                    Suggested: {suggestedLocation}
-                  </p>
-                )}
-
-                {/* Place search (#13), search for a place by name */}
-                <div className="space-y-1.5 pt-1">
-                  <div className="flex gap-2">
-                    <Input
-                      placeholder="Search for a place..."
-                      value={placeQuery}
-                      onChange={e => setPlaceQuery(e.target.value)}
-                      onKeyDown={e => { if (e.key === 'Enter') searchPlace() }}
-                      className="h-8 text-sm flex-1"
-                    />
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-8"
-                      onClick={searchPlace}
-                      disabled={isSearchingPlace || !placeQuery.trim()}
-                    >
-                      <MagnifyingGlass size={14} />
-                    </Button>
+                {(placeResults.length > 0 || isSearchingPlace) && (
+                  <div className="absolute z-50 top-full left-0 right-0 mt-1 rounded-md border bg-popover shadow-md max-h-40 overflow-y-auto">
+                    {isSearchingPlace && (
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground px-3 py-2">
+                        <div className="w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+                        Searching...
+                      </div>
+                    )}
+                    {placeResults.map((place) => (
+                      <button
+                        type="button"
+                        key={place.place_id}
+                        className="w-full text-left px-3 py-2 text-xs hover:bg-accent/50 active:bg-accent transition-colors"
+                        onClick={() => selectPlace(place)}
+                      >
+                        {place.display_name}
+                      </button>
+                    ))}
                   </div>
-                  {isSearchingPlace && (
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                      <div className="w-3 h-3 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-                      Searching...
-                    </div>
-                  )}
-                  {placeResults.length > 0 && (
-                    <div className="border rounded-md divide-y max-h-40 overflow-y-auto">
-                      {placeResults.map((place, i) => (
-                        <button
-                          key={i}
-                          className="w-full text-left px-3 py-2 text-xs hover:bg-muted active:bg-muted/80 transition-colors"
-                          onClick={() => selectPlace(place)}
-                        >
-                          {place.display_name}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                  {overriddenCoords && (
-                    <p className="text-xs text-green-600 dark:text-green-400">
-                      Location set: {overriddenCoords.lat.toFixed(4)}, {overriddenCoords.lon.toFixed(4)}
-                    </p>
-                  )}
-                </div>
-              </>
+                )}
+                {suggestedLocation && locationSearchQuery && suggestedLocation !== locationName && (
+                  <button
+                    type="button"
+                    className="text-xs text-primary hover:underline"
+                    onClick={() => {
+                      setLocationName(suggestedLocation)
+                      setOverriddenCoords(null)
+                      setInferredStateProvince(undefined)
+                      setInferredCountryCode(undefined)
+                      setIsEditingLocation(false)
+                      setLocationSearchQuery('')
+                      setPlaceResults([])
+                    }}
+                  >
+                    Use GPS: {suggestedLocation}
+                  </button>
+                )}
+              </div>
+            ) : (
+              <button
+                type="button"
+                className="w-full flex items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent/50 transition-colors text-left"
+                onClick={() => {
+                  setIsEditingLocation(true)
+                  setLocationSearchQuery(locationName)
+                }}
+              >
+                <span className={locationName ? 'text-foreground' : 'text-muted-foreground'}>
+                  {locationName || 'Tap to set location'}
+                </span>
+                <PencilSimple size={14} className="text-muted-foreground shrink-0" />
+              </button>
             )}
           </div>
           )}

--- a/src/components/pages/OutingsPage.tsx
+++ b/src/components/pages/OutingsPage.tsx
@@ -392,7 +392,8 @@ function OutingDetail({
     try {
       const response = await fetchWithLocalAuthRetry(`/api/export/outing/${outing.id}`, { credentials: 'include' })
       if (!response.ok) {
-        throw new Error(`Export failed (${response.status})`)
+        const body = await response.text().catch(() => '')
+        throw new Error(body || `Export failed (${response.status})`)
       }
 
       const blob = await response.blob()

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -56,6 +56,7 @@ export default function SettingsPage({ data, user, onSignIn, onSignedOut, onProf
   const [showEBirdHelp, setShowEBirdHelp] = useState(false)
   const [showImportDialog, setShowImportDialog] = useState(false)
   const [showConfetti, setShowConfetti] = useState(false)
+  const [deleteStep, setDeleteStep] = useState<'choose' | 'confirm-account' | null>(null)
   const [useGeoContext, setUseGeoContext] = useState(() => {
     const stored = localStorage.getItem('wingdex_useGeoContext')
     return stored === null ? true : stored === 'true'
@@ -279,7 +280,7 @@ export default function SettingsPage({ data, user, onSignIn, onSignedOut, onProf
 
       {user.isAnonymous && (
       <Card className="p-4 space-y-3">
-        <h3 className="font-semibold text-foreground">Account</h3>
+        <h3 className="font-semibold text-foreground">Profile</h3>
         <p className="text-sm text-muted-foreground">
           Create account or sign in to access your saved sightings and passkeys.
         </p>
@@ -293,7 +294,7 @@ export default function SettingsPage({ data, user, onSignIn, onSignedOut, onProf
       {!user.isAnonymous && (
       <Card className="p-4 space-y-4">
         <div className="space-y-2">
-          <h3 className="font-semibold text-foreground">Account</h3>
+          <h3 className="font-semibold text-foreground">Profile</h3>
           <p className="text-sm text-muted-foreground flex items-center gap-1.5">
             Welcome, <button
               type="button"
@@ -364,30 +365,6 @@ export default function SettingsPage({ data, user, onSignIn, onSignedOut, onProf
           })}
         </div>
 
-        {/* -- Log out -- */}
-        <div className="space-y-2">
-          <Button
-            variant="outline"
-            className="w-full justify-start"
-            onClick={async () => {
-              try {
-                const result = await authClient.signOut()
-                if (result.error) {
-                  toast.error(result.error.message || 'Failed to log out')
-                  return
-                }
-              } catch {
-                toast.error('Failed to log out')
-                return
-              }
-              toast.success('Logged out')
-              onSignedOut?.()
-            }}
-          >
-            <SignOut size={20} className="mr-2" />
-            Log out
-          </Button>
-        </div>
       </Card>
       )}
 
@@ -690,57 +667,12 @@ export default function SettingsPage({ data, user, onSignIn, onSignedOut, onProf
         </div>
       </Card>
 
-      {/* Data Storage & Privacy */}
+      {/* Account Management */}
       <Card className="p-4 space-y-4">
         <div className="space-y-2">
-          <h3 className="font-semibold text-foreground">Data Storage &amp; Privacy</h3>
+          <h3 className="font-semibold text-foreground">Account Management</h3>
           <p className="text-sm text-muted-foreground">
-            How your data is handled and stored
-          </p>
-        </div>
-        <div className="text-sm text-muted-foreground space-y-3 leading-relaxed">
-          <p>
-            <strong>Your photos are not retained.</strong>{' '}During identification,
-            compressed images are sent to WingDex&apos;s server-side AI endpoint for processing, then
-            discarded. We do store a file fingerprint hash to detect duplicate uploads.
-          </p>
-          <p>
-            Your birding records (outings, species, and sightings) are saved
-            to WingDex&apos;s Cloudflare-backed database, scoped to your account.
-          </p>
-          <p>
-            Location lookups use OpenStreetMap Nominatim to resolve GPS
-            coordinates into place names. Species images are loaded on-demand
-            from Wikimedia Commons. Species range data from{' '}
-            <a href="https://datazone.birdlife.org" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:text-foreground transition-colors">
-              BirdLife International
-            </a>{' '}
-            is used to refine identification confidence.
-          </p>
-          <p>
-            Learn more in our{' '}
-            <a href="#privacy" className="underline underline-offset-2 hover:text-foreground transition-colors">
-              Privacy Policy
-            </a>{' '}
-            and{' '}
-            <a href="#terms" className="underline underline-offset-2 hover:text-foreground transition-colors">
-              Terms of Use
-            </a>
-            . Questions or feedback can be shared on{' '}
-            <a href="https://github.com/jlian/wingdex/issues" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:text-foreground transition-colors">
-              GitHub
-            </a>
-            .
-          </p>
-        </div>
-      </Card>
-
-      {/* Data Management */}
-      <Card className="p-4 space-y-4">
-        <div className="space-y-2">
-          <h3 className="font-semibold text-foreground">Data Management</h3>
-          <p className="text-sm text-muted-foreground">
-            Load sample data or clear your account
+            Manage your data and account
           </p>
         </div>
         <div className="space-y-3">
@@ -777,7 +709,10 @@ export default function SettingsPage({ data, user, onSignIn, onSignedOut, onProf
                         credentials: 'include',
                         body: formData,
                       })
-                      if (!previewRes.ok) throw new Error(`Preview failed (${previewRes.status})`)
+                      if (!previewRes.ok) {
+                        const body = await previewRes.text().catch(() => '')
+                        throw new Error(body || `Preview failed (${previewRes.status})`)
+                      }
 
                       const { previews } = await previewRes.json() as {
                         previews: Array<{ previewId: string }>
@@ -789,7 +724,10 @@ export default function SettingsPage({ data, user, onSignIn, onSignedOut, onProf
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ previewIds: previews.map(p => p.previewId) }),
                       })
-                      if (!confirmRes.ok) throw new Error(`Confirm failed (${confirmRes.status})`)
+                      if (!confirmRes.ok) {
+                        const body = await confirmRes.text().catch(() => '')
+                        throw new Error(body || `Confirm failed (${confirmRes.status})`)
+                      }
 
                       const { imported } = await confirmRes.json() as {
                         imported: { outings: number; newSpecies: number }
@@ -809,102 +747,121 @@ export default function SettingsPage({ data, user, onSignIn, onSignedOut, onProf
             </AlertDialogContent>
           </AlertDialog>
 
-          <AlertDialog>
+          <AlertDialog open={deleteStep !== null} onOpenChange={open => { if (!open) setDeleteStep(null) }}>
             <AlertDialogTrigger asChild>
               <Button
                 variant="outline"
                 className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
+                onClick={() => setDeleteStep('choose')}
               >
                 <Trash size={20} className="mr-2" />
-                Delete All Data
+                Delete Data...
               </Button>
             </AlertDialogTrigger>
             <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete all data?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will permanently delete all your outings, observations,
-                  and WingDex entries. This action cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  onClick={() => {
-                    data.clearAllData()
-                    toast.success('All data deleted')
-                  }}
-                >
-                  Delete Everything
-                </AlertDialogAction>
-              </AlertDialogFooter>
+              {deleteStep === 'choose' && (
+                <>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Permanently delete data{!user.isAnonymous ? ' or account' : ''}?</AlertDialogTitle>
+                    <AlertDialogDescription asChild>
+                      <div className="space-y-3">
+                        <p>These actions are <strong className="text-foreground">permanent and irreversible</strong>.</p>
+                      </div>
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <div className="space-y-2">
+                    <AlertDialogAction
+                      className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      onClick={() => {
+                        data.clearAllData()
+                        toast.success('All data deleted')
+                        setDeleteStep(null)
+                      }}
+                    >
+                      Delete All Data
+                    </AlertDialogAction>
+                    {!user.isAnonymous && (
+                      <Button
+                        variant="destructive"
+                        className="w-full"
+                        onClick={() => setDeleteStep('confirm-account')}
+                      >
+                        Delete Account &amp; All Data
+                      </Button>
+                    )}
+                  </div>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  </AlertDialogFooter>
+                </>
+              )}
+              {deleteStep === 'confirm-account' && (
+                <>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle className="text-destructive">Are you absolutely sure?</AlertDialogTitle>
+                    <AlertDialogDescription asChild>
+                      <div className="space-y-3">
+                        <p>The following will be deleted immediately:</p>
+                        <ul className="list-disc pl-5 space-y-1 text-sm text-left">
+                          <li>All your outings and observations</li>
+                          <li>Your entire WingDex species list</li>
+                          <li>Your passkeys and login credentials</li>
+                          <li>Your account and profile</li>
+                        </ul>
+                        <p className="font-medium text-destructive">There is no way to recover your data after this.</p>
+                      </div>
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <Button variant="outline" onClick={() => setDeleteStep('choose')}>Go back</Button>
+                    <Button
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      onClick={async () => {
+                        try {
+                          const result = await authClient.deleteUser()
+                          if (result.error) {
+                            toast.error(result.error.message || 'Failed to delete account')
+                            return
+                          }
+                          data.clearAllData()
+                          setDeleteStep(null)
+                          toast.success('Account deleted')
+                          onSignedOut?.()
+                        } catch {
+                          toast.error('Failed to delete account')
+                        }
+                      }}
+                    >
+                      Delete my account forever
+                    </Button>
+                  </AlertDialogFooter>
+                </>
+              )}
             </AlertDialogContent>
           </AlertDialog>
 
           {!user.isAnonymous && (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button
-                  variant="outline"
-                  className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30"
-                >
-                  <Trash size={20} className="mr-2" weight="fill" />
-                  Delete Account &amp; All Data
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle className="text-destructive">⚠️ Delete your entire account?</AlertDialogTitle>
-                  <AlertDialogDescription asChild>
-                    <div className="space-y-3">
-                      <p>This is <strong className="text-foreground">permanent and irreversible</strong>. The following will be deleted immediately:</p>
-                      <ul className="list-disc pl-5 space-y-1 text-sm text-left">
-                        <li>All your outings and observations</li>
-                        <li>Your entire WingDex species list</li>
-                        <li>Your passkeys and login credentials</li>
-                        <li>Your account and profile</li>
-                      </ul>
-                      <p className="font-medium text-destructive">There is no way to recover your data after this.</p>
-                    </div>
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button variant="destructive">I understand, continue</Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle className="text-destructive">Are you absolutely sure?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          This will permanently delete your account and all associated data. You will be signed out immediately. This cannot be undone.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Go back</AlertDialogCancel>
-                        <AlertDialogAction
-                          className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                          onClick={async () => {
-                            try {
-                              data.clearAllData()
-                              await authClient.deleteUser()
-                              toast.success('Account deleted')
-                              onSignedOut?.()
-                            } catch {
-                              toast.error('Failed to delete account')
-                            }
-                          }}
-                        >
-                          Delete my account forever
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+            <Button
+              variant="outline"
+              className="w-full justify-start"
+              onClick={async () => {
+                try {
+                  const result = await authClient.signOut()
+                  if (result.error) {
+                    toast.error(result.error.message || 'Failed to log out')
+                    return
+                  }
+                } catch {
+                  toast.error('Failed to log out')
+                  return
+                }
+                toast.success('Logged out')
+                onSignedOut?.()
+              }}
+            >
+              <SignOut size={20} className="mr-2" />
+              Log out
+            </Button>
           )}
         </div>
       </Card>

--- a/src/lib/demo-data.ts
+++ b/src/lib/demo-data.ts
@@ -13,7 +13,10 @@ export async function loadDemoData(data: WingDexDataStore): Promise<void> {
     credentials: 'include',
     body: formData,
   })
-  if (!previewRes.ok) throw new Error(`Preview failed (${previewRes.status})`)
+  if (!previewRes.ok) {
+    const body = await previewRes.text().catch(() => '')
+    throw new Error(body || `Preview failed (${previewRes.status})`)
+  }
 
   const { previews } = await previewRes.json() as { previews: Array<{ previewId: string }> }
 
@@ -23,7 +26,10 @@ export async function loadDemoData(data: WingDexDataStore): Promise<void> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ previewIds: previews.map((p) => p.previewId) }),
   })
-  if (!confirmRes.ok) throw new Error(`Confirm failed (${confirmRes.status})`)
+  if (!confirmRes.ok) {
+    const body = await confirmRes.text().catch(() => '')
+    throw new Error(body || `Confirm failed (${confirmRes.status})`)
+  }
 
   await data.refresh()
 }


### PR DESCRIPTION
## Summary

Two UX fixes for the web app to better align with iOS.

### Settings page (#219)

- Rename "Account" section to "Profile"
- Remove "Data Storage & Privacy" card (already covered in footer)
- Combine "Data Management" and "Log out" into a single "Account Management" card
- Merge "Delete All Data" and "Delete Account & All Data" into one button with choices in the modal
- Match iOS confirmation flow for delete actions (single confirm for data, double confirm for account)
- Log out button now at the bottom of the page where users expect it

### Location search (#234)

- Replace two separate inputs (outing name autocomplete + place search) with an iOS-style display/edit toggle
- Default state: tappable location row with pencil icon
- Edit mode: "Search for a place..." field with debounced Nominatim results in a floating dropdown
- Enter to use typed text as-is, Escape to cancel, tap a result to select
- "Use GPS" shortcut when the auto-geocoded suggestion differs from the search

Closes #219
Closes #234