### PR TITLE
fix(range): scan full 3x3 neighbor ring for range priors

### DIFF
--- a/functions/lib/range-adjust.js
+++ b/functions/lib/range-adjust.js
@@ -73,10 +73,10 @@ export function nearestNeighborCell(x, y, row, col) {
  * range-edge points frequently fall in a cell that lacks a species whose
  * range polygon covers an adjacent (often diagonal) cell.
  *
-  * `nearestNeighborCell` only returns the single closest edge cell, which
-  * misses diagonals and the other three edges; a point right on a coastline
-  * can read out-of-range for a species that is plainly present one cell over.
-  * This returns up to 8 cells so callers can scan the full ring.
+ * `nearestNeighborCell` only returns the single closest edge cell, which
+ * misses diagonals and the other three edges; a point right on a coastline
+ * can read out-of-range for a species that is plainly present one cell over.
+ * This returns up to 8 cells so callers can scan the full ring.
  */
 export function neighborCells(x, y, row, col) {
   const fx = (x - (GRID_ORIGIN_X + col * GRID_CELL_SIZE)) / GRID_CELL_SIZE

--- a/functions/lib/range-adjust.js
+++ b/functions/lib/range-adjust.js
@@ -66,6 +66,38 @@ export function nearestNeighborCell(x, y, row, col) {
   return { row: nr, col: nc }
 }
 
+/**
+ * All in-bounds neighbor cells in the 3x3 ring around (row, col), ordered by
+ * proximity to the point's position within its cell (closest edge/corner
+ * first). Used to blend range data across cell boundaries: coastal and
+ * range-edge points frequently fall in a cell that lacks a species whose
+ * range polygon covers an adjacent (often diagonal) cell.
+ *
+ * `nearestNeighborCell` only returns the single closest edge cell, which
+ * misses diagonals and the other three edges — a point right on a coastline
+ * can read out-of-range for a species that is plainly present one cell over.
+ * This returns up to 8 cells so callers can scan the full ring.
+ */
+export function neighborCells(x, y, row, col) {
+  const fx = (x - (GRID_ORIGIN_X + col * GRID_CELL_SIZE)) / GRID_CELL_SIZE
+  const fy = ((GRID_ORIGIN_Y - row * GRID_CELL_SIZE) - y) / GRID_CELL_SIZE
+  const out = []
+  for (let dr = -1; dr <= 1; dr++) {
+    for (let dc = -1; dc <= 1; dc++) {
+      if (dr === 0 && dc === 0) continue
+      const nr = row + dr, nc = col + dc
+      if (nr < 0 || nr >= GRID_ROWS || nc < 0 || nc >= GRID_COLS) continue
+      // squared distance from the point to the target cell (0 if inside the
+      // shared edge/corner direction); used only for ordering.
+      const ddx = dc === -1 ? fx : dc === 1 ? 1 - fx : 0
+      const ddy = dr === -1 ? fy : dr === 1 ? 1 - fy : 0
+      out.push({ row: nr, col: nc, dist: ddx * ddx + ddy * ddy })
+    }
+  }
+  out.sort((a, b) => a.dist - b.dist)
+  return out.map(({ row, col }) => ({ row, col }))
+}
+
 // ── Blob parsing ────────────────────────────────────────────
 
 /**

--- a/functions/lib/range-adjust.js
+++ b/functions/lib/range-adjust.js
@@ -73,10 +73,10 @@ export function nearestNeighborCell(x, y, row, col) {
  * range-edge points frequently fall in a cell that lacks a species whose
  * range polygon covers an adjacent (often diagonal) cell.
  *
- * `nearestNeighborCell` only returns the single closest edge cell, which
- * misses diagonals and the other three edges — a point right on a coastline
- * can read out-of-range for a species that is plainly present one cell over.
- * This returns up to 8 cells so callers can scan the full ring.
+  * `nearestNeighborCell` only returns the single closest edge cell, which
+  * misses diagonals and the other three edges; a point right on a coastline
+  * can read out-of-range for a species that is plainly present one cell over.
+  * This returns up to 8 cells so callers can scan the full ring.
  */
 export function neighborCells(x, y, row, col) {
   const fx = (x - (GRID_ORIGIN_X + col * GRID_CELL_SIZE)) / GRID_CELL_SIZE

--- a/functions/lib/range-filter.ts
+++ b/functions/lib/range-filter.ts
@@ -89,13 +89,18 @@ export async function getRangePriors(
     if (outOfRange.length > 0) {
       const neighbors = neighborCells(x, y, cell.row, cell.col)
       const remaining = new Set(outOfRange)
-      if (neighbors.length > 0) {
-        // Fetch all ring cells in parallel (network latency dominates), but
-        // defer decompression: decompress + parse sequentially closest-first
-        // and stop as soon as every species is resolved, so a hit in the
-        // nearest cell avoids decompressing the farther ones.
-        const neighborBlobs = await Promise.all(
-          neighbors.map(async n => {
+      // Progressive fan-out: process the ring in closest-first waves and only
+      // fetch farther cells if species are still unresolved. Coastal points
+      // are usually resolved by the 1-2 nearest cells, so this avoids issuing
+      // all 8 R2 GETs on the hot path while preserving closest-first winner
+      // semantics. Within a wave, cells are fetched in parallel (network
+      // latency dominates) and decompressed lazily closest-first with early
+      // exit. Worst case is a handful of small waves rather than 8 GETs.
+      const WAVE_SIZE = 2
+      for (let i = 0; i < neighbors.length && remaining.size > 0; i += WAVE_SIZE) {
+        const wave = neighbors.slice(i, i + WAVE_SIZE)
+        const waveBlobs = await Promise.all(
+          wave.map(async n => {
             try {
               const nObj = await bucket.get(`range-priors/${n.row}-${n.col}.bin.gz`)
               if (!nObj) return null
@@ -105,8 +110,8 @@ export async function getRangePriors(
             }
           }),
         )
-        // Scan closest-first so the nearest containing cell wins.
-        for (const blob of neighborBlobs) {
+        // Scan closest-first within the wave so the nearest containing cell wins.
+        for (const blob of waveBlobs) {
           if (remaining.size === 0) break
           if (!blob) continue
           let nData: Uint8Array

--- a/functions/lib/range-filter.ts
+++ b/functions/lib/range-filter.ts
@@ -10,7 +10,7 @@
 import {
   lonLatToEqualEarth,
   xyToCell,
-  nearestNeighborCell,
+  neighborCells,
   parseCellBlob,
   adjustConfidence as _adjustConfidence,
 } from './range-adjust.js'
@@ -77,28 +77,43 @@ export async function getRangePriors(
       }
     }
 
-    // Neighbor blending for out-of-range species
+    // Neighbor blending for out-of-range species. Scan the full 3x3 ring
+    // (up to 8 cells) rather than only the single closest edge cell: coastal
+    // and range-edge points often fall in a cell that lacks a species whose
+    // BirdLife polygon covers an adjacent (frequently diagonal) cell, which
+    // the old single-neighbor lookup reported as out-of-range. Cells are
+    // fetched in parallel and scanned closest-first; a species is marked
+    // near-range on the first ring cell that contains it.
     if (outOfRange.length > 0) {
-      const neighbor = nearestNeighborCell(x, y, cell.row, cell.col)
-      if (neighbor) {
-        try {
-          const nObj = await bucket.get(`range-priors/${neighbor.row}-${neighbor.col}.bin.gz`)
-          if (nObj) {
-            const nData = await decompressBlob(await nObj.arrayBuffer())
-            const nMap = parseCellBlob(new Uint8Array(nData), new Set(outOfRange))
-            for (const code of outOfRange) {
-              const attrs = nMap.get(code)
-              results.set(code, attrs ? { status: 'near-range', ...attrs } : OUT_OF_RANGE)
+      const neighbors = neighborCells(x, y, cell.row, cell.col)
+      const remaining = new Set(outOfRange)
+      if (neighbors.length > 0) {
+        const neighborData = await Promise.all(
+          neighbors.map(async n => {
+            try {
+              const nObj = await bucket.get(`range-priors/${n.row}-${n.col}.bin.gz`)
+              if (!nObj) return null
+              return new Uint8Array(await decompressBlob(await nObj.arrayBuffer()))
+            } catch {
+              return null
             }
-          } else {
-            for (const code of outOfRange) results.set(code, OUT_OF_RANGE)
+          }),
+        )
+        // Scan closest-first so the nearest containing cell wins.
+        for (const nData of neighborData) {
+          if (remaining.size === 0) break
+          if (!nData) continue
+          const nMap = parseCellBlob(nData, remaining)
+          for (const code of [...remaining]) {
+            const attrs = nMap.get(code)
+            if (attrs) {
+              results.set(code, { status: 'near-range', ...attrs })
+              remaining.delete(code)
+            }
           }
-        } catch {
-          for (const code of outOfRange) results.set(code, OUT_OF_RANGE)
         }
-      } else {
-        for (const code of outOfRange) results.set(code, OUT_OF_RANGE)
       }
+      for (const code of remaining) results.set(code, OUT_OF_RANGE)
     }
   } catch {
     for (const code of ebirdCodes) results.set(code, NO_DATA)

--- a/functions/lib/range-filter.ts
+++ b/functions/lib/range-filter.ts
@@ -35,8 +35,10 @@ async function decompressBlob(compressed: ArrayBuffer): Promise<ArrayBuffer> {
 /**
  * Look up range status for multiple species at a single location.
  *
- * For species not found in the primary cell, checks the nearest neighbor
- * cell (based on point position) and upgrades those to 'near-range'.
+ * For species not found in the primary cell, scans the full 3x3 ring of
+ * neighbor cells (up to 8) in parallel, closest-first, and upgrades a species
+ * to 'near-range' on the first neighbor cell that contains it. Species absent
+ * from the primary cell and every neighbor are marked 'out-of-range'.
  */
 export async function getRangePriors(
   bucket: R2Bucket,
@@ -88,21 +90,31 @@ export async function getRangePriors(
       const neighbors = neighborCells(x, y, cell.row, cell.col)
       const remaining = new Set(outOfRange)
       if (neighbors.length > 0) {
-        const neighborData = await Promise.all(
+        // Fetch all ring cells in parallel (network latency dominates), but
+        // defer decompression: decompress + parse sequentially closest-first
+        // and stop as soon as every species is resolved, so a hit in the
+        // nearest cell avoids decompressing the farther ones.
+        const neighborBlobs = await Promise.all(
           neighbors.map(async n => {
             try {
               const nObj = await bucket.get(`range-priors/${n.row}-${n.col}.bin.gz`)
               if (!nObj) return null
-              return new Uint8Array(await decompressBlob(await nObj.arrayBuffer()))
+              return await nObj.arrayBuffer()
             } catch {
               return null
             }
           }),
         )
         // Scan closest-first so the nearest containing cell wins.
-        for (const nData of neighborData) {
+        for (const blob of neighborBlobs) {
           if (remaining.size === 0) break
-          if (!nData) continue
+          if (!blob) continue
+          let nData: Uint8Array
+          try {
+            nData = new Uint8Array(await decompressBlob(blob))
+          } catch {
+            continue
+          }
           const nMap = parseCellBlob(nData, remaining)
           for (const code of [...remaining]) {
             const attrs = nMap.get(code)

--- a/functions/lib/range-filter.ts
+++ b/functions/lib/range-filter.ts
@@ -35,10 +35,12 @@ async function decompressBlob(compressed: ArrayBuffer): Promise<ArrayBuffer> {
 /**
  * Look up range status for multiple species at a single location.
  *
- * For species not found in the primary cell, scans the full 3x3 ring of
- * neighbor cells (up to 8) in parallel, closest-first, and upgrades a species
- * to 'near-range' on the first neighbor cell that contains it. Species absent
- * from the primary cell and every neighbor are marked 'out-of-range'.
+ * For species not found in the primary cell, scans the 3x3 ring of neighbor
+ * cells (up to 8) closest-first using progressive fan-out (small parallel
+ * waves), and upgrades a species to 'near-range' on the first neighbor cell
+ * that contains it. Farther cells are only fetched if species remain
+ * unresolved, so the common case touches just the 1-2 nearest cells. Species
+ * absent from the primary cell and every neighbor are marked 'out-of-range'.
  */
 export async function getRangePriors(
   bucket: R2Bucket,
@@ -95,7 +97,8 @@ export async function getRangePriors(
       // all 8 R2 GETs on the hot path while preserving closest-first winner
       // semantics. Within a wave, cells are fetched in parallel (network
       // latency dominates) and decompressed lazily closest-first with early
-      // exit. Worst case is a handful of small waves rather than 8 GETs.
+      // exit. Worst case (nothing resolves early) still issues up to 8 GETs,
+      // but spread across several small sequential waves rather than all at once.
       const WAVE_SIZE = 2
       for (let i = 0; i < neighbors.length && remaining.size > 0; i += WAVE_SIZE) {
         const wave = neighbors.slice(i, i + WAVE_SIZE)

--- a/src/__tests__/range-filter.test.ts
+++ b/src/__tests__/range-filter.test.ts
@@ -25,6 +25,30 @@ function mockBucket(records: Uint8Array[]): any {
   }
 }
 
+/**
+ * Cell-aware mock bucket: maps `range-priors/<row>-<col>.bin.gz` keys to
+ * distinct record sets, so neighbor-cell blending can be tested. Missing
+ * keys return null (ocean/empty cell).
+ */
+function mockBucketByCell(cellRecords: Record<string, Uint8Array[]>): any {
+  const compressedByKey: Record<string, Buffer> = {}
+  for (const [key, records] of Object.entries(cellRecords)) {
+    const raw = new Uint8Array(records.reduce((n, r) => n + r.length, 0))
+    let offset = 0
+    for (const r of records) { raw.set(r, offset); offset += r.length }
+    compressedByKey[key] = gzipSync(Buffer.from(raw))
+  }
+  return {
+    get: vi.fn(async (key: string) => {
+      const compressed = compressedByKey[key]
+      if (!compressed) return null
+      return {
+        arrayBuffer: async () => compressed.buffer.slice(compressed.byteOffset, compressed.byteOffset + compressed.byteLength),
+      }
+    }),
+  }
+}
+
 function emptyBucket(): any {
   return { get: vi.fn(async () => null) }
 }
@@ -114,6 +138,39 @@ describe('getRangePriors', () => {
     const result = await getRangePriors(bucket, SEATTLE_LAT, SEATTLE_LON, 5, [])
     expect(result.size).toBe(0)
     expect(bucket.get).not.toHaveBeenCalled()
+  })
+
+  // Seattle (47.6, -122.3) maps to grid cell 96-272; its ring includes 96-273
+  // (closest edge), 95-273 (a diagonal), etc.
+  const SELF_KEY = 'range-priors/96-272.bin.gz'
+
+  it('finds a species present in a diagonal neighbor cell (8-neighbor blend)', async () => {
+    // norcar is absent from the self cell but present in the diagonal 95-273.
+    // The old single-neighbor lookup only checked the closest edge (96-273)
+    // and would have returned out-of-range; the 3x3 ring scan finds it.
+    const bucket = mockBucketByCell({
+      [SELF_KEY]: [makeRecord('baleag', EXTANT, NATIVE, RESIDENT)],
+      'range-priors/95-273.bin.gz': [makeRecord('norcar', EXTANT, NATIVE, RESIDENT)],
+    })
+    const result = await getRangePriors(bucket, SEATTLE_LAT, SEATTLE_LON, 5, ['norcar'])
+    expect(result.get('norcar')).toEqual({ status: 'near-range', presence: EXTANT, origin: NATIVE, seasonal: RESIDENT })
+  })
+
+  it('prefers present (self cell) over near-range even if also in a neighbor', async () => {
+    const bucket = mockBucketByCell({
+      [SELF_KEY]: [makeRecord('baleag', EXTANT, NATIVE, RESIDENT)],
+      'range-priors/96-273.bin.gz': [makeRecord('baleag', EXTANT, NATIVE, BREEDING)],
+    })
+    const result = await getRangePriors(bucket, SEATTLE_LAT, SEATTLE_LON, 5, ['baleag'])
+    expect(result.get('baleag')?.status).toBe('present')
+  })
+
+  it('stays out-of-range when absent from self cell and all 8 neighbors', async () => {
+    const bucket = mockBucketByCell({
+      [SELF_KEY]: [makeRecord('baleag', EXTANT, NATIVE, RESIDENT)],
+    })
+    const result = await getRangePriors(bucket, SEATTLE_LAT, SEATTLE_LON, 5, ['norcar'])
+    expect(result.get('norcar')).toEqual({ status: 'out-of-range' })
   })
 })
 

--- a/src/__tests__/range-filter.test.ts
+++ b/src/__tests__/range-filter.test.ts
@@ -165,6 +165,21 @@ describe('getRangePriors', () => {
     expect(result.get('baleag')?.status).toBe('present')
   })
 
+  it('uses the closest neighbor when a species is in multiple ring cells', async () => {
+    // For self cell 96-272, the ring is ordered closest-first as
+    // 96-273 (closest edge) then 95-273 (a diagonal). norcar is absent from
+    // the self cell but present in BOTH neighbors with different attributes;
+    // the closest-first scan must win, so the 96-273 record (RESIDENT) is used,
+    // not the farther 95-273 record (BREEDING).
+    const bucket = mockBucketByCell({
+      [SELF_KEY]: [makeRecord('baleag', EXTANT, NATIVE, RESIDENT)],
+      'range-priors/96-273.bin.gz': [makeRecord('norcar', EXTANT, NATIVE, RESIDENT)],
+      'range-priors/95-273.bin.gz': [makeRecord('norcar', EXTANT, VAGRANT, BREEDING)],
+    })
+    const result = await getRangePriors(bucket, SEATTLE_LAT, SEATTLE_LON, 5, ['norcar'])
+    expect(result.get('norcar')).toEqual({ status: 'near-range', presence: EXTANT, origin: NATIVE, seasonal: RESIDENT })
+  })
+
   it('stays out-of-range when absent from self cell and all 8 neighbors', async () => {
     const bucket = mockBucketByCell({
       [SELF_KEY]: [makeRecord('baleag', EXTANT, NATIVE, RESIDENT)],


### PR DESCRIPTION
## Problem

The range-prior lookup in `getRangePriors` only checked a **single** neighbor cell. `nearestNeighborCell` returns just the closest edge cell (left/right/top/bottom, whichever the point is nearest), never diagonals or the other three edges.

For observations near coastlines or range boundaries, a species' BirdLife range polygon often covers an **adjacent diagonal** or non-nearest-edge cell. The single-neighbor lookup misses those and wrongly reports `out-of-range`, which then penalizes the correct species' confidence.

### Concrete example
Great Blue Heron at Drayton Harbor (48.98, -122.79):
- **Before:** `out-of-range` (single-neighbor miss)
- **After:** `near-range` (present in an adjacent cell, found by the 3x3 ring scan)

Belted Kingfisher (Carkeek Park) is unaffected (`present` in self cell). Tufted Puffin at Smith Island stays `out-of-range` even at 5x5, that's a genuine gap in the coarse 27km BirdLife raster, not a lookup bug.

## Change

- Add `neighborCells()` to `range-adjust.js`: returns up to 8 in-bounds cells in the 3x3 ring, ordered closest-first.
- `getRangePriors()` scans the ring closest-first using **progressive fan-out** (small parallel waves of 2): it fetches the nearest cells first and only fans out to farther cells if species remain unresolved, marking a species `near-range` on the first cell that contains it. Self-cell `present` still wins; species absent from the whole ring stay `out-of-range`.
- Latency/cost: the common case (resolved by the 1-2 nearest cells) issues just 1-2 neighbor R2 GETs; worst case still touches up to 8 cells, but spread across a few small sequential waves rather than a single all-8 `Promise.all`. Neighbor fetches only happen when there are out-of-range species to resolve.
- `nearestNeighborCell` is retained (still used by offline benchmark scripts).

## Tests

- New cell-aware mock bucket maps `range-priors/<row>-<col>.bin.gz` keys to distinct cells.
- Added coverage: diagonal-neighbor blend produces `near-range`; self-cell `present` takes precedence over a neighbor; species absent from self + all 8 neighbors stays `out-of-range`.
- All 19 range-filter tests pass; `tsc --noEmit` and eslint clean.

## Context

Found while spiking on-device BioCLIP-2 bird ID (separate branch), where coastal false-negatives showed up clearly. This fix stands on its own and improves the current GPT pipeline too.
