### PR TITLE
ci(preview): isolate preview deploys per PR (fix shared-URL overwrite)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,6 @@ jobs:
               state: 'success',
               environment_url: previewUrl || undefined,
             });
-            core.setOutput('preview_url', previewUrl);
 
       # Sticky comment so reviewers always have the per-PR preview URL.
       - name: Comment preview URL on PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,14 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      # Skip deploy when the release workflow already handles this branch
+      # Skip deploy when the release workflow already handles this branch.
+      # Use per-PR aliased preview URLs so concurrent PRs don't overwrite each
+      # other. `wrangler versions upload --preview-alias pr-<N>` creates a
+      # version with a stable alias URL of the form
+      #   pr-<N>-wingdex-app-preview.<subdomain>.workers.dev
+      # (requires preview_urls = true in wrangler.toml). Unlike `deploy`, this
+      # does NOT change the live deployed version — each PR only gets its own
+      # isolated preview URL.
       - name: Deploy preview to Cloudflare Workers
         if: github.head_ref != 'dev' && github.head_ref != 'main'
         id: deploy_preview
@@ -83,16 +90,22 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env preview
+          command: versions upload --env preview --preview-alias pr-${{ github.event.pull_request.number }}
 
       - name: Branch preview deployment
         if: github.head_ref != 'dev' && github.head_ref != 'main'
         uses: actions/github-script@v7
         env:
-          PREVIEW_URL: ${{ steps.deploy_preview.outputs['deployment-url'] || '' }}
+          # Prefer the alias URL wrangler actually printed (robust to subdomain
+          # changes); fall back to the deterministic constructed URL.
+          COMMAND_OUTPUT: ${{ steps.deploy_preview.outputs['command-output'] || '' }}
+          FALLBACK_ALIAS_URL: https://pr-${{ github.event.pull_request.number }}-wingdex-app-preview.lianguanlun.workers.dev
         with:
           script: |
-            const previewUrl = process.env.PREVIEW_URL || '';
+            const out = process.env.COMMAND_OUTPUT || '';
+            // wrangler prints e.g. "Version Preview URL: https://pr-259-...workers.dev"
+            const m = out.match(/https:\/\/pr-[a-z0-9-]+-wingdex-app-preview\.[a-z0-9-]+\.workers\.dev/i);
+            const previewUrl = (m && m[0]) || process.env.FALLBACK_ALIAS_URL;
             const { data: deployment } = await github.rest.repos.createDeployment({
               ...context.repo,
               ref: '${{ github.event.pull_request.head.sha }}',
@@ -107,3 +120,30 @@ jobs:
               state: 'success',
               environment_url: previewUrl || undefined,
             });
+            core.setOutput('preview_url', previewUrl);
+
+      # Sticky comment so reviewers always have the per-PR preview URL.
+      - name: Comment preview URL on PR
+        if: github.head_ref != 'dev' && github.head_ref != 'main'
+        uses: actions/github-script@v7
+        env:
+          COMMAND_OUTPUT: ${{ steps.deploy_preview.outputs['command-output'] || '' }}
+          FALLBACK_ALIAS_URL: https://pr-${{ github.event.pull_request.number }}-wingdex-app-preview.lianguanlun.workers.dev
+        with:
+          script: |
+            const out = process.env.COMMAND_OUTPUT || '';
+            const m = out.match(/https:\/\/pr-[a-z0-9-]+-wingdex-app-preview\.[a-z0-9-]+\.workers\.dev/i);
+            const url = (m && m[0]) || process.env.FALLBACK_ALIAS_URL;
+            const marker = '<!-- preview-url -->';
+            const body = `${marker}\n🔎 **Preview for this PR:** ${url}\n\n_Isolated per-PR alias — no longer shared/overwritten across PRs. Updates on every push._`;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       # version with a stable alias URL of the form
       #   pr-<N>-wingdex-app-preview.<subdomain>.workers.dev
       # (requires preview_urls = true in wrangler.toml). Unlike `deploy`, this
-      # does NOT change the live deployed version — each PR only gets its own
+      # does NOT change the live deployed version; each PR only gets its own
       # isolated preview URL.
       - name: Deploy preview to Cloudflare Workers
         if: github.head_ref != 'dev' && github.head_ref != 'main'
@@ -135,8 +135,9 @@ jobs:
             const m = out.match(/https:\/\/pr-[a-z0-9-]+-wingdex-app-preview\.[a-z0-9-]+\.workers\.dev/i);
             const url = (m && m[0]) || process.env.FALLBACK_ALIAS_URL;
             const marker = '<!-- preview-url -->';
-            const body = `${marker}\n🔎 **Preview for this PR:** ${url}\n\n_Isolated per-PR alias — no longer shared/overwritten across PRs. Updates on every push._`;
-            const { data: comments } = await github.rest.issues.listComments({
+            const body = `${marker}\n🔎 **Preview for this PR:** ${url}\n\n_Isolated per-PR alias, no longer shared/overwritten across PRs. Updates on every push._`;
+            // Paginate: the sticky marker may be beyond the first page on busy PRs.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               ...context.repo,
               issue_number: context.issue.number,
               per_page: 100,


### PR DESCRIPTION
## Problem

After the Pages → Workers migration, **every PR overwrites the same preview deployment.**

The CI deploy step ran `wrangler deploy --env preview`, which always targets the single Worker named `wingdex-app-preview` (from `[env.preview]` + top-level `name = "wingdex-app"`). So all open PRs deploy to the **same** URL — `wingdex-app-preview.lianguanlun.workers.dev` — and last-deploy-wins. They also shared the preview D1 (`wingdex-db-dev`) and R2 buckets, so "the preview" reflected whichever PR deployed most recently, not the PR you were looking at.

Pages used to give per-branch preview URLs for free; the migration silently dropped that isolation.

## Fix

Use **per-PR aliased preview URLs**:

- Deploy step now runs `wrangler versions upload --env preview --preview-alias pr-<PR#>`. This creates a version with a stable alias URL of the form `pr-<PR#>-wingdex-app-preview.<subdomain>.workers.dev` (needs `preview_urls = true`, already set). Unlike `deploy`, it does **not** change the live/deployed version — each PR only gets its own isolated preview URL.
- The GitHub deployment status + a **sticky PR comment** surface the per-PR URL (parsed from wrangler's output, with a deterministic fallback).

## Result

- PR #258 → `pr-258-wingdex-app-preview...`
- PR #259 → `pr-259-wingdex-app-preview...`
- This PR → `pr-<n>-wingdex-app-preview...`

No more stomping. Each in-flight PR has an independent preview.

## Notes / caveats

- **Shared preview state remains.** All previews still point at the same `wingdex-db-dev` and the `wingdex-range-priors` / `wingdex-models` R2 buckets (these bindings are account-global). This PR isolates the *code/URL*, not the data. Fully isolating per-PR D1/R2 is a bigger change; flagging it but out of scope here.
- Preview aliases don't need explicit cleanup — re-uploading with the same `pr-<N>` alias reuses it, and old versions age out per Cloudflare retention. The existing `cleanup-preview.yml` (deactivates GitHub deployment records on PR close) is unchanged.
- Prod is unaffected: production deploys happen via `release.yml` on merge to `main`, not this step.

**Priority:** merge first, then the two in-flight PRs (#258, #259) get correct isolated previews once rebased/updated onto this.