### PR TITLE
ci: drop preview sticky comment + fix Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: read
       deployments: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
@@ -86,7 +85,7 @@ jobs:
       - name: Deploy preview to Cloudflare Workers
         if: github.head_ref != 'dev' && github.head_ref != 'main'
         id: deploy_preview
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -94,10 +93,11 @@ jobs:
 
       - name: Branch preview deployment
         if: github.head_ref != 'dev' && github.head_ref != 'main'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           # Prefer the alias URL wrangler actually printed (robust to subdomain
-          # changes); fall back to the deterministic constructed URL.
+          # changes); fall back to the deterministic constructed URL. The URL is
+          # surfaced on the PR via the GitHub deployment/Environments UI.
           COMMAND_OUTPUT: ${{ steps.deploy_preview.outputs['command-output'] || '' }}
           FALLBACK_ALIAS_URL: https://pr-${{ github.event.pull_request.number }}-wingdex-app-preview.lianguanlun.workers.dev
         with:
@@ -120,30 +120,3 @@ jobs:
               state: 'success',
               environment_url: previewUrl || undefined,
             });
-
-      # Sticky comment so reviewers always have the per-PR preview URL.
-      - name: Comment preview URL on PR
-        if: github.head_ref != 'dev' && github.head_ref != 'main'
-        uses: actions/github-script@v7
-        env:
-          COMMAND_OUTPUT: ${{ steps.deploy_preview.outputs['command-output'] || '' }}
-          FALLBACK_ALIAS_URL: https://pr-${{ github.event.pull_request.number }}-wingdex-app-preview.lianguanlun.workers.dev
-        with:
-          script: |
-            const out = process.env.COMMAND_OUTPUT || '';
-            const m = out.match(/https:\/\/pr-[a-z0-9-]+-wingdex-app-preview\.[a-z0-9-]+\.workers\.dev/i);
-            const url = (m && m[0]) || process.env.FALLBACK_ALIAS_URL;
-            const marker = '<!-- preview-url -->';
-            const body = `${marker}\n🔎 **Preview for this PR:** ${url}\n\n_Isolated per-PR alias, no longer shared/overwritten across PRs. Updates on every push._`;
-            // Paginate: the sticky marker may be beyond the first page on busy PRs.
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              ...context.repo,
-              issue_number: context.issue.number,
-              per_page: 100,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ ...context.repo, issue_number: context.issue.number, body });
-            }

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deactivate preview deployments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/rotate-apple-secret.yml
+++ b/.github/workflows/rotate-apple-secret.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Generate Apple client secret JWT
         id: jwt
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const crypto = require('crypto');


### PR DESCRIPTION
Follow-up to #262. Two cleanups + address the Node 20 deprecation notices.

## 1. Remove the preview sticky-comment step

The `Comment preview URL on PR` step auto-posted (and re-posted on every push) a comment like [this one](https://github.com/jlian/wingdex/pull/262#issuecomment-5030887775). It's redundant: the per-PR preview URL is already surfaced on the PR via the **GitHub deployment / Environments UI** (the `Branch preview deployment` step sets `environment_url`). Removing the comment cuts the noise. Also drops the now-unused `pull-requests: write` permission from the CI job (least privilege).

## 2. Fix Node 20 deprecation warnings

CI was emitting:
> Node 20 is being deprecated. This workflow is running with Node 24 by default...

Source: actions still pinned to Node 20 runtimes. Bumped to Node 24:
- `cloudflare/wrangler-action@v3` → `@v4` (ci.yml, release.yml). v4's only major change is `wranglerVersion` input flexibility (version ranges/tags); no behavior change for our exact-command usage.
- `actions/github-script@v7` → `@v9` (ci.yml, cleanup-preview.yml, rotate-apple-secret.yml). v9 runs on node24.

All other actions (`checkout@v6`, `setup-node@v6`, `cache@v5`) were already on Node 24.

## Verification
- All 9 workflow files validated as parseable YAML.
- No `@v3` wrangler-action / `@v7` github-script references remain.
- Preview isolation (from #262) is unchanged: still `versions upload --preview-alias pr-<N>`.

_Note: separately, the Copilot review comments on #259 are being handled on that PR._