### PR TITLE
fix(ios): add location purpose string to xcodegen project.yml (ITMS-90683)

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -57,6 +57,7 @@ targets:
         UILaunchScreen: {}
         UIApplicationSupportsIndirectInputEvents: true
         NSCameraUsageDescription: "WingDex uses the camera so you can take bird photos for identification."
+        NSLocationWhenInUseUsageDescription: "WingDex uses your location to tag where a bird photo was taken, which improves identification accuracy."
         NSPhotoLibraryUsageDescription: "WingDex uses your photo library so you can choose bird photos to identify."
         NSPhotoLibraryAddUsageDescription: "WingDex may save captured bird photos to your library when you choose to keep them."
         UISupportedInterfaceOrientations:


### PR DESCRIPTION
## Problem

The 0.6.1 (build 1) TestFlight upload (merge of #268) **still** triggered `ITMS-90683: Missing purpose string in Info.plist` for `NSLocationWhenInUseUsageDescription`, even though #268 added that key to `ios/WingDex/Info.plist`.

## Root cause

CI generates the Xcode project with **xcodegen** (`xcodegen generate` in `.github/workflows/ios.yml` and the release workflow). xcodegen's `info.properties` block in `ios/project.yml` **regenerates `Info.plist` from scratch and overwrites** the checked-in file. That block listed the camera and photo-library purpose strings but **not** the location one, so the hand-added key in `Info.plist` was wiped during the archive, and the uploaded binary shipped without it.

The simulator test build passed because tests don't inspect the plist; only the App Store archive/validation caught it.

## Fix

Add `NSLocationWhenInUseUsageDescription` to the `info.properties` block in `ios/project.yml` (the real source of truth). The tracked `WingDex/Info.plist` already has the key (from #268) and is kept in sync; `project.yml` was the missing piece.

## Verification

- [ ] Next TestFlight upload (build after this merge) does **not** get ITMS-90683.
- The generated `Info.plist` will now contain the location purpose string because xcodegen writes every `properties:` entry into it.

Follow-up to #268 / #266.
