### PR TITLE
fix: unblur species heroes with no larger image, bound iOS image memory

### DIFF
--- a/ios/WingDex/Services/ImageLoader.swift
+++ b/ios/WingDex/Services/ImageLoader.swift
@@ -87,9 +87,16 @@ final class ImageLoader {
         "\(url)|\(Int(targetPoints.rounded()))"
     }
 
+    /// `UITraitCollection.current` is only populated while a view is updating, so it reads
+    /// 0 when a prefetch runs outside that window. The attached window's traits are the
+    /// reliable source.
     private static var displayScale: CGFloat {
-        let scale = UITraitCollection.current.displayScale
-        return scale > 0 ? scale : 3
+        let windowScale = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow?.traitCollection.displayScale }
+            .first { $0 > 0 }
+        if let windowScale { return windowScale }
+        let currentScale = UITraitCollection.current.displayScale
+        return currentScale > 0 ? currentScale : 2
     }
 }
 

--- a/ios/WingDex/Views/SharedComponents.swift
+++ b/ios/WingDex/Views/SharedComponents.swift
@@ -220,7 +220,11 @@ struct BirdThumbnail: View {
     }
 
     private func loadImage() async {
-        if let loaded = await ImageLoader.shared.image(for: url, targetPoints: size) { uiImage = loaded }
+        guard let loaded = await ImageLoader.shared.image(for: url, targetPoints: size) else { return }
+        // The loader deliberately outlives its caller, so a load for a previous `url` can
+        // still land here and overwrite the current row's image.
+        guard !Task.isCancelled else { return }
+        uiImage = loaded
     }
 
     private var placeholder: some View {

--- a/ios/WingDex/Views/SpeciesCarousel.swift
+++ b/ios/WingDex/Views/SpeciesCarousel.swift
@@ -167,8 +167,8 @@ struct SpeciesCarousel: UIViewRepresentable {
             willPerformPreviewActionForMenuWith configuration: UIContextMenuConfiguration,
             animator: any UIContextMenuInteractionCommitAnimating
         ) {
-            guard let speciesName = configuration.identifier as? String,
-                  let entry = entries.first(where: { $0.id == speciesName })
+            guard let entryId = configuration.identifier as? String,
+                  let entry = entries.first(where: { $0.id == entryId })
             else { return }
             animator.preferredCommitStyle = .pop
             animator.addCompletion { [weak self] in self?.onSelect(entry) }

--- a/ios/WingDex/Views/SpeciesDetailView.swift
+++ b/ios/WingDex/Views/SpeciesDetailView.swift
@@ -1,21 +1,31 @@
 import SwiftUI
 
+/// Reference type because `NSCache` only stores class instances.
+private final class WikiSummary: Sendable {
+    let extract: String?
+    let imageUrl: String?
+
+    init(extract: String?, imageUrl: String?) {
+        self.extract = extract
+        self.imageUrl = imageUrl
+    }
+}
+
 /// Wikipedia summaries are cached in memory because a context-menu preview and the view
 /// it pops into are separate `SpeciesDetailView` instances with separate state. Without
 /// this the pushed view refetches the summary, so it has no full-res URL on its first
 /// render and replays the blur-up even though the image is already decoded.
 @MainActor
 private final class WikiSummaryCache {
-    struct Summary {
-        let extract: String?
-        let imageUrl: String?
+    static let shared = WikiSummaryCache()
+    private let cache = NSCache<NSString, WikiSummary>()
+
+    init(countLimit: Int = 128) {
+        cache.countLimit = countLimit
     }
 
-    static let shared = WikiSummaryCache()
-    private var cache: [String: Summary] = [:]
-
-    func summary(for title: String) -> Summary? { cache[title] }
-    func set(_ summary: Summary, for title: String) { cache[title] = summary }
+    func summary(for title: String) -> WikiSummary? { cache.object(forKey: title as NSString) }
+    func set(_ summary: WikiSummary, for title: String) { cache.setObject(summary, forKey: title as NSString) }
 }
 
 struct SpeciesDetailView: View {
@@ -35,7 +45,7 @@ struct SpeciesDetailView: View {
 
     /// Read through to the cache so a preview-populated summary is available on the first
     /// render, before `.task` has a chance to run.
-    private var cachedSummary: WikiSummaryCache.Summary? {
+    private var cachedSummary: WikiSummary? {
         guard let wikiTitle = entry?.wikiTitle else { return nil }
         return WikiSummaryCache.shared.summary(for: wikiTitle)
     }
@@ -292,12 +302,7 @@ struct SpeciesDetailView: View {
 
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else { return }
-            let original = json["originalimage"] as? [String: Any]
-            let summary = WikiSummaryCache.Summary(
-                extract: json["extract"] as? String,
-                imageUrl: original?["source"] as? String
-            )
+            guard let summary = await Self.parseSummary(data) else { return }
             WikiSummaryCache.shared.set(summary, for: wikiTitle)
             wikiExtract = summary.extract
             fullImageUrl = summary.imageUrl
@@ -305,6 +310,21 @@ struct SpeciesDetailView: View {
             // Silently fail - the dex thumbnail is still shown. Not cached, so a later
             // visit retries.
         }
+    }
+
+    /// Off the main actor: extracts run to several KB, and this parse lands on the detail
+    /// push path where a hitch is visible.
+    private nonisolated static func parseSummary(_ data: Data) async -> WikiSummary? {
+        await Task.detached(priority: .utility) {
+            guard let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+                return nil
+            }
+            let original = json["originalimage"] as? [String: Any]
+            return WikiSummary(
+                extract: json["extract"] as? String,
+                imageUrl: original?["source"] as? String
+            )
+        }.value
     }
 
     private var heroImageURL: URL? {

--- a/src/components/pages/WingDexPage.tsx
+++ b/src/components/pages/WingDexPage.tsx
@@ -445,7 +445,7 @@ function SpeciesDetail({
               src={baseImageUrl}
               alt={canShowOverlay ? '' : displayName}
               aria-hidden={canShowOverlay}
-              className={`absolute inset-0 w-full h-full object-cover object-[center_10%] ${thumbnailUrl ? 'blur-md scale-105' : ''}`}
+              className={`absolute inset-0 w-full h-full object-cover object-[center_10%] ${canShowOverlay ? 'blur-md scale-105' : ''}`}
             />
           )}
           {/* Full-res overlay fades in over the base layer */}


### PR DESCRIPTION
Follow-up to #273. These are the review fixes from that PR; they were committed locally but missed the merge.

- Web: the hero blur was gated on `thumbnailUrl` being truthy, so a species whose dex thumbnail is an original (no `/thumb/` segment, no larger rendering) had no full-res overlay to fade in and stayed blurred forever. Now gated on whether a distinct full-res URL actually exists.
- iOS: `WikiSummaryCache` was an unbounded dictionary that never evicted. Switched to `NSCache` with a count limit, which meant making the summary a reference type.
- iOS: the Wikipedia summary JSON was parsed on the main actor, right on the detail push path this branch is trying to keep smooth. Moved to a detached task.
- iOS: `ImageLoader.displayScale` fell back to 3x when `UITraitCollection.current` was unset, which over-downsamples on 2x devices. Reads the attached window's traits first now. Avoided `UIScreen.main` since it's deprecated at our iOS 26 deployment target.
- iOS: `BirdThumbnail` now checks `Task.isCancelled` before assigning. Loads deliberately outlive their caller, so a late one could overwrite a recycled row.

Also renamed a misleading local in `SpeciesCarousel` (`speciesName` holding an entry id).

Verified: iOS build clean, 111 iOS tests pass, hero URL vitest suite passes, `tsc --noEmit` and eslint clean.
