### PR TITLE
ci(ios-release): revoke CI-created signing certificates after upload

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -163,6 +163,58 @@ jobs:
             --apiKey "${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}" \
             --apiIssuer "${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}"
 
+      # Runners start with an empty keychain, so -allowProvisioningUpdates mints a fresh
+      # development certificate every run. Left alone they pile up until the account cap
+      # is hit. Their private keys die with the runner, so revoking them is always safe.
+      - name: Revoke CI-created signing certificates
+        if: always() && steps.semrel.outputs.released == 'true' && inputs.dry_run != true
+        continue-on-error: true
+        uses: actions/github-script@v9
+        env:
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+        with:
+          script: |
+            const crypto = require('crypto');
+
+            const privateKey = Buffer.from(process.env.ASC_PRIVATE_KEY, 'base64').toString('utf8');
+            const now = Math.floor(Date.now() / 1000);
+            const b64 = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+            const signingInput = [
+              b64({ alg: 'ES256', kid: process.env.ASC_KEY_ID, typ: 'JWT' }),
+              b64({ iss: process.env.ASC_ISSUER_ID, iat: now, exp: now + 600, aud: 'appstoreconnect-v1' }),
+            ].join('.');
+            const sig = crypto.sign('sha256', Buffer.from(signingInput), {
+              key: crypto.createPrivateKey(privateKey),
+              dsaEncoding: 'ieee-p1363',
+            });
+            const token = `${signingInput}.${sig.toString('base64url')}`;
+
+            async function asc(path, method = 'GET') {
+              const res = await fetch(`https://api.appstoreconnect.apple.com${path}`, {
+                method,
+                headers: { Authorization: `Bearer ${token}` },
+              });
+              if (!res.ok) {
+                throw new Error(`${method} ${path} -> ${res.status} ${await res.text()}`);
+              }
+              return res.status === 204 ? null : res.json();
+            }
+
+            // Xcode names every certificate it creates through the API "Created via API".
+            const REVOCABLE = new Set(['DEVELOPMENT', 'IOS_DEVELOPMENT', 'MAC_APP_DEVELOPMENT']);
+            const { data } = await asc('/v1/certificates?limit=200');
+            const stale = data.filter(
+              (c) => c.attributes.displayName === 'Created via API' && REVOCABLE.has(c.attributes.certificateType),
+            );
+
+            core.info(`${data.length} certificate(s) on the account, ${stale.length} CI-created`);
+            for (const cert of stale) {
+              await asc(`/v1/certificates/${cert.id}`, 'DELETE');
+              core.info(`Revoked ${cert.attributes.certificateType} ${cert.id} (expiry ${cert.attributes.expirationDate})`);
+            }
+
       - name: Clean up API key
         if: always()
         run: rm -rf ~/.appstoreconnect

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -178,6 +178,12 @@ jobs:
           script: |
             const crypto = require('crypto');
 
+            const missing = ['ASC_KEY_ID', 'ASC_ISSUER_ID', 'ASC_PRIVATE_KEY'].filter((k) => !process.env[k]);
+            if (missing.length) {
+              core.setFailed(`Missing required App Store Connect secrets: ${missing.join(', ')}`);
+              return;
+            }
+
             const privateKey = Buffer.from(process.env.ASC_PRIVATE_KEY, 'base64').toString('utf8');
             const now = Math.floor(Date.now() / 1000);
             const b64 = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
@@ -210,9 +216,20 @@ jobs:
             );
 
             core.info(`${data.length} certificate(s) on the account, ${stale.length} CI-created`);
+
+            // Best effort per certificate: one failure must not strand the rest.
+            let failed = 0;
             for (const cert of stale) {
-              await asc(`/v1/certificates/${cert.id}`, 'DELETE');
-              core.info(`Revoked ${cert.attributes.certificateType} ${cert.id} (expiry ${cert.attributes.expirationDate})`);
+              try {
+                await asc(`/v1/certificates/${cert.id}`, 'DELETE');
+                core.info(`Revoked ${cert.attributes.certificateType} ${cert.id} (expiry ${cert.attributes.expirationDate})`);
+              } catch (err) {
+                failed += 1;
+                core.warning(`Could not revoke ${cert.id}: ${err.message}`);
+              }
+            }
+            if (failed) {
+              core.setFailed(`${failed} of ${stale.length} certificate(s) could not be revoked`);
             }
 
       - name: Clean up API key


### PR DESCRIPTION
The last iOS release failed at the archive step with:

```
error: Choose a certificate to revoke. Your account has reached the maximum number of certificates.
error: No profiles for 'app.wingdex.share' were found ...
```

Runners start with an empty keychain, so `-allowProvisioningUpdates` mints a fresh Apple Development certificate on every archive. Nothing ever cleaned them up, so after ~12 releases the account hit its cert cap. The second error is just a cascade of the first.

The usual advice is to store a distribution `.p12` as a secret and switch to manual signing, but that trades this problem for a yearly manual cert re-export. Since the private key for each CI cert dies with the runner, those certs are unusable by anyone and can just be revoked instead.

So this adds a cleanup step after the TestFlight upload that revokes them via the App Store Connect API. No new secrets, no manual rotation, and `-allowProvisioningUpdates` stays as is.

Details:

- Reuses the existing `APP_STORE_CONNECT_*` secrets and the same ES256 JWT signing pattern already in `rotate-apple-secret.yml`.
- Lists all certs and filters client side rather than using `filter[certificateType]`, so a wrong enum value can't turn into a 400.
- Only revokes certs where `displayName` is `Created via API` and the type is in an explicit development allowlist. Personally created and distribution certs can't match.
- `if: always()` so a failed archive still cleans up the cert it created, and `continue-on-error: true` so cleanup problems can't fail an otherwise good release.

It sweeps all CI-created dev certs rather than only the current run's, which also cleans up leaks from cancelled runs. Safe because `concurrency: release-${{ github.ref_name }}` with `cancel-in-progress: false` keeps release runs serialized.

Verified the API key has revoke permission and that archiving works again after manually clearing the backlog.