### PR TITLE
fix(ios): show offline banner only after a refresh fails

### DIFF
--- a/ios/WingDex/Services/DataStore.swift
+++ b/ios/WingDex/Services/DataStore.swift
@@ -143,9 +143,12 @@ final class DataStore {
                   activeAccountID == accountID,
                   loadRequestID == requestID
             else { return }
-            self.error = AppError.map(error)
-            refreshFailed = true
-            log.error("Failed to load account data")
+            // A cancellation maps to nil and isn't a refresh failure.
+            if let mappedError = AppError.map(error) {
+                self.error = mappedError
+                refreshFailed = true
+                log.error("Failed to load account data")
+            }
         }
         if generation == loadGeneration,
            activeAccountID == accountID,

--- a/ios/WingDex/Services/DataStore.swift
+++ b/ios/WingDex/Services/DataStore.swift
@@ -52,8 +52,10 @@ final class DataStore {
     private(set) var hasLoadedAll = false
     private(set) var cachedAt: Date?
     private(set) var activeAccountID: String?
+    private(set) var refreshFailed = false
     var hasReadableData: Bool { cachedAt != nil || hasLoadedAll }
-    var isShowingCachedData: Bool { cachedAt != nil && !hasLoadedAll }
+    /// Stale data is only worth calling out once a refresh has actually failed.
+    var isShowingCachedData: Bool { cachedAt != nil && !hasLoadedAll && refreshFailed }
 
     // MARK: - Dependencies
 
@@ -129,6 +131,7 @@ final class DataStore {
             confirmedSnapshot = response
             hasLoadedAll = true
             cachedAt = nil
+            refreshFailed = false
             do {
                 try cache?.replace(accountID: accountID, response: response, refreshedAt: .now)
             } catch {
@@ -141,6 +144,7 @@ final class DataStore {
                   loadRequestID == requestID
             else { return }
             self.error = AppError.map(error)
+            refreshFailed = true
             log.error("Failed to load account data")
         }
         if generation == loadGeneration,
@@ -164,6 +168,7 @@ final class DataStore {
         error = nil
         hasLoadedAll = false
         cachedAt = nil
+        refreshFailed = false
         activeAccountID = nil
         confirmedSnapshot = nil
         loadRequestID = UUID()

--- a/ios/WingDexTests/DataStoreCacheTests.swift
+++ b/ios/WingDexTests/DataStoreCacheTests.swift
@@ -98,6 +98,7 @@ final class DataStoreCacheTests: XCTestCase {
         XCTAssertTrue(store.hasReadableData)
         XCTAssertFalse(store.hasLoadedAll)
         XCTAssertNotNil(store.cachedAt)
+        XCTAssertFalse(store.isShowingCachedData)
         XCTAssertThrowsError(try storeMutationReadiness(store))
     }
 
@@ -114,6 +115,7 @@ final class DataStoreCacheTests: XCTestCase {
         XCTAssertEqual(store.outings.first?.locationName, "Cached Marsh")
         XCTAssertEqual(store.error, .offline)
         XCTAssertFalse(store.hasLoadedAll)
+        XCTAssertTrue(store.isShowingCachedData)
     }
 
     func testFirstLaunchOfflineHasNoReadableSnapshot() async {

--- a/ios/WingDexTests/DataStoreCacheTests.swift
+++ b/ios/WingDexTests/DataStoreCacheTests.swift
@@ -118,6 +118,20 @@ final class DataStoreCacheTests: XCTestCase {
         XCTAssertTrue(store.isShowingCachedData)
     }
 
+    func testCancelledRefreshDoesNotFlagCachedData() async {
+        let cache = CacheStub(snapshot: AccountDataSnapshot(
+            response: fixtureResponse(locationName: "Cached Marsh"),
+            refreshedAt: .now
+        ))
+        let store = DataStore(service: ServiceStub(result: .failure(URLError(.cancelled))), cache: cache)
+        store.activate(accountID: "account-a")
+
+        await store.loadAll()
+
+        XCTAssertNil(store.error)
+        XCTAssertFalse(store.isShowingCachedData)
+    }
+
     func testFirstLaunchOfflineHasNoReadableSnapshot() async {
         let cache = CacheStub(snapshot: nil)
         let store = DataStore(


### PR DESCRIPTION
Fixes #274

The cached-data banner was gated on `cachedAt != nil && !hasLoadedAll`. On launch we hydrate the disk cache first, so `cachedAt` is set and `hasLoadedAll` is still false for the entire duration of the refresh. That meant every cold start showed "Offline data - reconnect to make changes" for a moment even on a perfectly good connection.

Now `DataStore` tracks whether the last `loadAll()` actually failed, and the banner is gated on that too. Nothing shows while the refresh is in flight; the banner only appears once a refresh has genuinely failed and we are still on cached data, and it clears as soon as a refresh succeeds. If you retry while still offline, the banner stays put.

Tests: added assertions to `DataStoreCacheTests` that the banner is hidden right after cache hydration and visible after an offline refresh. `DataStoreCacheTests` passes locally (20 tests, 0 failures).

One thing I deliberately left alone: when you are offline with cached data, `HomeView`/`OutingsView`/`WingDexView` also pop an error alert, so you get both the alert and the banner. Suppressing that alert when readable cached data exists would get closer to how Music behaves, but it felt like a separate change.
