### PR TITLE
fix(ios-release): check out the branch tip so queued releases are not stale

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,39 @@
+name: Commitlint
+
+# The PR title is validated separately by semantic-pr-title.yml. This validates the
+# individual commit messages in the PR, which nothing checked before.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: commitlint-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need both branch tips so the PR commit range can be resolved.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Validate commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npx commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -12,14 +12,6 @@ on:
         description: 'Validate tests, archive, and export without publishing or uploading'
         type: boolean
         default: false
-      release_version:
-        description: 'Existing ios-v version to rebuild/upload (for example, 0.8.0)'
-        type: string
-        required: false
-      build_number:
-        description: 'Unused App Store build number (required with release_version)'
-        type: string
-        required: false
 
 concurrency:
   group: release-${{ github.ref_name }}
@@ -44,28 +36,7 @@ jobs:
 
       - name: Check for iOS-relevant changes since last tag
         id: diff
-        env:
-          RELEASE_VERSION: ${{ inputs.release_version }}
-          BUILD_NUMBER: ${{ inputs.build_number }}
         run: |
-          if [ -n "$RELEASE_VERSION" ]; then
-            if ! echo "$RELEASE_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-              echo "::error::release_version must use semantic version format, for example 0.8.0"
-              exit 1
-            fi
-            if ! echo "$BUILD_NUMBER" | grep -qE '^[1-9][0-9]*$'; then
-              echo "::error::build_number is required with release_version and must be a positive integer"
-              exit 1
-            fi
-            if ! git rev-parse --verify --quiet "refs/tags/ios-v${RELEASE_VERSION}"; then
-              echo "::error::Tag ios-v${RELEASE_VERSION} does not exist"
-              exit 1
-            fi
-            echo "Rebuilding existing ios-v${RELEASE_VERSION}"
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           LAST_TAG=$(git tag --list 'ios-v*' --sort=-v:refname | head -1)
           if [ -z "$LAST_TAG" ]; then
             echo "No previous ios-v tag found - first release"
@@ -91,21 +62,18 @@ jobs:
       has_release: ${{ steps.version.outputs.has_release }}
       source_sha: ${{ steps.source_sha.outputs.sha }}
     steps:
-      # Two modes, and the difference matters:
-      #   release_version set -> rebuild a shipped release, so check out that tag's
-      #     app source. Today's main would give current code wearing an old version.
-      #   normal release -> check out the BRANCH TIP, not github.sha. This workflow
-      #     shares the release-<ref> concurrency group with release.yml, so it can
-      #     start only after that workflow already pushed a version-bump commit to
-      #     main. A checkout pinned to the triggering sha is then one commit behind
-      #     the remote and semantic-release refuses to release from a stale branch:
-      #     "The local branch main is behind the remote one". github.ref resolves at
-      #     execution time, so it includes that bump.
-      # Fixed once in 8a72195, then silently reverted by 60189c3 when the tag path
-      # arrived, which broke the 2026-08-10 release. Do not put github.sha back.
+      # Check out the BRANCH TIP, not github.sha. This workflow shares the
+      # release-<ref> concurrency group with release.yml, so it can start only
+      # after that workflow already pushed a version-bump commit to main. A
+      # checkout pinned to the triggering sha is then one commit behind the remote
+      # and semantic-release refuses to release from a stale branch: "The local
+      # branch main is behind the remote one". github.ref resolves at execution
+      # time, so it includes that bump.
+      # Fixed once in 8a72195, then reverted by 60189c3 and b8f9dd9, which broke
+      # the 2026-08-10 release. Do not put github.sha back.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_version && format('refs/tags/ios-v{0}', inputs.release_version) || github.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -115,22 +83,6 @@ jobs:
       - name: Record the built source commit
         id: source_sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      # Rebuilding an existing release checks out the app source at its tag, but
-      # older tags predate CI tooling this job needs. ios-v0.8.0, for example, has
-      # neither scripts/inspect-archive.sh nor the pinned Package.resolved that
-      # -onlyUsePackageVersionsFromResolvedFile requires, so the rebuild would fail
-      # before upload. Restore just those files from the dispatching commit so the
-      # tagged app builds with current release tooling. The normal release path
-      # already checks out the branch tip, so it needs nothing here.
-      - name: Restore release tooling from current commit
-        if: inputs.release_version != ''
-        env:
-          TOOLING_REF: ${{ github.sha }}
-        run: |
-          git checkout "$TOOLING_REF" -- \
-            ios/scripts/inspect-archive.sh \
-            ios/WingDex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 
       - uses: actions/setup-node@v6
         with:
@@ -148,14 +100,7 @@ jobs:
         working-directory: ios
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EXISTING_VERSION: ${{ inputs.release_version }}
         run: |
-          if [ -n "$EXISTING_VERSION" ]; then
-            echo "release_version=$EXISTING_VERSION" >> "$GITHUB_OUTPUT"
-            echo "has_release=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           OUTPUT=$(npx semantic-release --dry-run 2>&1)
           echo "$OUTPUT"
           NEXT_VERSION=$(echo "$OUTPUT" | awk '
@@ -182,9 +127,7 @@ jobs:
       - name: Apply release version locally
         if: steps.version.outputs.has_release == 'true'
         working-directory: ios
-        env:
-          BUILD_NUMBER: ${{ inputs.build_number }}
-        run: scripts/bump-version.sh set "${{ steps.version.outputs.release_version }}" "${BUILD_NUMBER:-1}" --quiet
+        run: scripts/bump-version.sh set "${{ steps.version.outputs.release_version }}" --quiet
 
       - name: Generate Xcode project
         if: steps.version.outputs.has_release == 'true'
@@ -427,21 +370,17 @@ jobs:
           persist-credentials: false
 
       - uses: actions/setup-node@v6
-        if: inputs.release_version == ''
         with:
           node-version: 24
           cache: npm
 
       - name: Install npm dependencies
-        if: inputs.release_version == ''
         run: npm ci
 
       - name: Install XcodeGen
-        if: inputs.release_version == ''
         run: brew install xcodegen
 
       - name: Publish semantic release
-        if: inputs.release_version == ''
         working-directory: ios
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -471,7 +410,6 @@ jobs:
         run: rm -rf ~/.appstoreconnect
 
       - name: Mark pre-1.0 releases as prerelease
-        if: inputs.release_version == ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -484,8 +422,4 @@ jobs:
       - name: Summary
         run: |
           echo "### iOS Release v${{ needs.preflight.outputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
-          if [ -n "${{ inputs.release_version }}" ]; then
-            echo "Rebuilt and uploaded existing release as build ${{ inputs.build_number }}." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Published and uploaded to TestFlight." >> "$GITHUB_STEP_SUMMARY"
-          fi
+          echo "Published and uploaded to TestFlight." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -90,20 +90,21 @@ jobs:
       release_version: ${{ steps.version.outputs.release_version }}
       has_release: ${{ steps.version.outputs.has_release }}
     steps:
-      - name: Resolve source ref
-        id: source
-        env:
-          RELEASE_VERSION: ${{ inputs.release_version }}
-        run: |
-          if [ -n "$RELEASE_VERSION" ]; then
-            echo "ref=refs/tags/ios-v${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-          fi
-
+      # Two modes, and the difference matters:
+      #   release_version set -> rebuild a shipped release, so check out that tag's
+      #     app source. Today's main would give current code wearing an old version.
+      #   normal release -> check out the BRANCH TIP, not github.sha. This workflow
+      #     shares the release-<ref> concurrency group with release.yml, so it can
+      #     start only after that workflow already pushed a version-bump commit to
+      #     main. A checkout pinned to the triggering sha is then one commit behind
+      #     the remote and semantic-release refuses to release from a stale branch:
+      #     "The local branch main is behind the remote one". github.ref resolves at
+      #     execution time, so it includes that bump.
+      # Fixed once in 8a72195, then silently reverted by 60189c3 when the tag path
+      # arrived, which broke the 2026-08-10 release. Do not put github.sha back.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ steps.source.outputs.ref }}
+          ref: ${{ inputs.release_version && format('refs/tags/ios-v{0}', inputs.release_version) || github.ref }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -113,7 +114,7 @@ jobs:
       # -onlyUsePackageVersionsFromResolvedFile requires, so the rebuild would fail
       # before upload. Restore just those files from the dispatching commit so the
       # tagged app builds with current release tooling. The normal release path
-      # already checks out GITHUB_SHA, so it needs nothing here.
+      # already checks out the branch tip, so it needs nothing here.
       - name: Restore release tooling from current commit
         if: inputs.release_version != ''
         env:
@@ -404,9 +405,13 @@ jobs:
     if: needs.check.outputs.should_release == 'true' && needs.preflight.outputs.has_release == 'true' && inputs.dry_run != true
     runs-on: macos-26
     steps:
+      # Same branch-tip requirement as preflight: this job runs semantic-release,
+      # which refuses to publish when the local branch is behind the remote. The
+      # release-<ref> concurrency group means release.yml may already have pushed a
+      # version bump to main before this starts.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.release_version && format('refs/tags/ios-v{0}', inputs.release_version) || github.ref }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -89,6 +89,7 @@ jobs:
     outputs:
       release_version: ${{ steps.version.outputs.release_version }}
       has_release: ${{ steps.version.outputs.has_release }}
+      source_sha: ${{ steps.source_sha.outputs.sha }}
     steps:
       # Two modes, and the difference matters:
       #   release_version set -> rebuild a shipped release, so check out that tag's
@@ -107,6 +108,13 @@ jobs:
           ref: ${{ inputs.release_version && format('refs/tags/ios-v{0}', inputs.release_version) || github.ref }}
           fetch-depth: 0
           persist-credentials: false
+
+      # Pin everything downstream to the exact commit this job built, so publish
+      # cannot silently release a newer one if main advances during the macOS
+      # archive (several minutes).
+      - name: Record the built source commit
+        id: source_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       # Rebuilding an existing release checks out the app source at its tag, but
       # older tags predate CI tooling this job needs. ios-v0.8.0, for example, has
@@ -405,13 +413,16 @@ jobs:
     if: needs.check.outputs.should_release == 'true' && needs.preflight.outputs.has_release == 'true' && inputs.dry_run != true
     runs-on: macos-26
     steps:
-      # Same branch-tip requirement as preflight: this job runs semantic-release,
-      # which refuses to publish when the local branch is behind the remote. The
-      # release-<ref> concurrency group means release.yml may already have pushed a
-      # version bump to main before this starts.
+      # Check out the exact commit preflight built and versioned, NOT the branch tip.
+      # Preflight already resolved the tip to pick up any version bump release.yml
+      # pushed while this run was queued. Re-resolving here would open a second
+      # window: another merge can advance main during the macOS archive, and
+      # semantic-release would then tag commits that are not in the IPA this job
+      # uploads. Pinning keeps the released tag, the version, and the artifact in
+      # agreement.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_version && format('refs/tags/ios-v{0}', inputs.release_version) || github.ref }}
+          ref: ${{ needs.preflight.outputs.source_sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,6 +13,11 @@ export default {
       'always',
       ['feat', 'fix', 'docs', 'chore', 'perf', 'refactor', 'test', 'ci', 'build', 'revert'],
     ],
+    // CONTRIBUTING.md documents type(scope): description, but 8 of the last 60
+    // commits on main omit the scope. Warn rather than fail so the check can land
+    // without blocking in-flight work; raise to 2 once new commits consistently
+    // carry one.
+    'scope-empty': [1, 'never'],
     // Scopes in this repo are mixed case on purpose: fix(Auth), ci(ios-release).
     'scope-case': [0],
     // Subjects here are sentences, not slugs; only forbid a trailing period.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,25 @@
+// Conventional Commits, matching CONTRIBUTING.md.
+//
+// The PR *title* is already checked by semantic-pr-title.yml. This checks the
+// individual *commit* messages, which nothing validated before, and which end up
+// in the changelog because releases squash-merge on the PR title but rebase-merge
+// keeps them verbatim.
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // CONTRIBUTING.md lists exactly these types.
+    'type-enum': [
+      2,
+      'always',
+      ['feat', 'fix', 'docs', 'chore', 'perf', 'refactor', 'test', 'ci', 'build', 'revert'],
+    ],
+    // Scopes in this repo are mixed case on purpose: fix(Auth), ci(ios-release).
+    'scope-case': [0],
+    // Subjects here are sentences, not slugs; only forbid a trailing period.
+    'subject-case': [0],
+    'header-max-length': [2, 'always', 100],
+    // Bodies wrap at 80 in this repo, but semantic-release and revert commits
+    // generate longer lines, so warn instead of failing.
+    'body-max-line-length': [1, 'always', 100],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,8 @@
             "devDependencies": {
                 "@aws-sdk/client-s3": "^3.1013.0",
                 "@cloudflare/workers-types": "^5.20260804.1",
+                "@commitlint/cli": "^21.2.1",
+                "@commitlint/config-conventional": "^21.2.0",
                 "@eslint/js": "^9.21.0",
                 "@playwright/test": "^1.58.2",
                 "@semantic-release/changelog": "^6.0.3",
@@ -1561,6 +1563,375 @@
             "optional": true,
             "engines": {
                 "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@commitlint/cli": {
+            "version": "21.2.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.2.1.tgz",
+            "integrity": "sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/config-conventional": "^21.2.0",
+                "@commitlint/format": "^21.2.0",
+                "@commitlint/lint": "^21.2.0",
+                "@commitlint/load": "^21.2.0",
+                "@commitlint/read": "^21.2.1",
+                "@commitlint/types": "^21.2.0",
+                "tinyexec": "^1.0.0",
+                "yargs": "^18.0.0"
+            },
+            "bin": {
+                "commitlint": "cli.js"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/config-conventional": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.2.0.tgz",
+            "integrity": "sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/types": "^21.2.0",
+                "conventional-changelog-conventionalcommits": "^10.0.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/config-validator": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.2.0.tgz",
+            "integrity": "sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/types": "^21.2.0",
+                "ajv": "^8.11.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/config-validator/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@commitlint/ensure": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.2.0.tgz",
+            "integrity": "sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/types": "^21.2.0",
+                "es-toolkit": "^1.46.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/execute-rule": {
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+            "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/format": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.2.0.tgz",
+            "integrity": "sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/types": "^21.2.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/is-ignored": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.2.0.tgz",
+            "integrity": "sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/types": "^21.2.0",
+                "semver": "^7.6.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/lint": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.2.0.tgz",
+            "integrity": "sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/is-ignored": "^21.2.0",
+                "@commitlint/parse": "^21.2.0",
+                "@commitlint/rules": "^21.2.0",
+                "@commitlint/types": "^21.2.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/load": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.2.0.tgz",
+            "integrity": "sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/config-validator": "^21.2.0",
+                "@commitlint/execute-rule": "^21.0.1",
+                "@commitlint/resolve-extends": "^21.2.0",
+                "@commitlint/types": "^21.2.0",
+                "cosmiconfig": "^9.0.1",
+                "cosmiconfig-typescript-loader": "^6.1.0",
+                "es-toolkit": "^1.46.0",
+                "is-plain-obj": "^4.1.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/message": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.2.0.tgz",
+            "integrity": "sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/parse": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.2.0.tgz",
+            "integrity": "sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/types": "^21.2.0",
+                "conventional-changelog-angular": "^9.0.0",
+                "conventional-commits-parser": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/parse/node_modules/conventional-changelog-angular": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.2.1.tgz",
+            "integrity": "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@conventional-changelog/template": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@commitlint/parse/node_modules/conventional-commits-parser": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+            "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^2.0.0",
+                "argue-cli": "^3.1.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@commitlint/read": {
+            "version": "21.2.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.2.1.tgz",
+            "integrity": "sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/top-level": "^21.2.0",
+                "@commitlint/types": "^21.2.0",
+                "@conventional-changelog/git-client": "^3.0.0",
+                "tinyexec": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/read/node_modules/@conventional-changelog/git-client": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.1.tgz",
+            "integrity": "sha512-w/q+UIVdWQMgXlziPIYfPlyDud+H8kcvSCzDQQoc/gid7yZzb6eNfAkNN4UlEcS2cVVh924jevsOIb36d0In2g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/child-process-utils": "^2.0.0",
+                "@simple-libs/stream-utils": "^2.0.0",
+                "semver": "^7.5.2"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "peerDependencies": {
+                "conventional-commits-filter": "^6.0.1",
+                "conventional-commits-parser": "^7.1.2"
+            },
+            "peerDependenciesMeta": {
+                "conventional-commits-filter": {
+                    "optional": true
+                },
+                "conventional-commits-parser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@commitlint/resolve-extends": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
+            "integrity": "sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/config-validator": "^21.2.0",
+                "@commitlint/types": "^21.2.0",
+                "es-toolkit": "^1.46.0",
+                "global-directory": "^5.0.0",
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/resolve-extends/node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@commitlint/rules": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.2.0.tgz",
+            "integrity": "sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@commitlint/ensure": "^21.2.0",
+                "@commitlint/message": "^21.2.0",
+                "@commitlint/to-lines": "^21.0.1",
+                "@commitlint/types": "^21.2.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/to-lines": {
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+            "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/top-level": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.2.0.tgz",
+            "integrity": "sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "escalade": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/types": {
+            "version": "21.2.0",
+            "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.2.0.tgz",
+            "integrity": "sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "conventional-commits-parser": "^7.0.0",
+                "picocolors": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=22.12.0"
+            }
+        },
+        "node_modules/@commitlint/types/node_modules/conventional-commits-parser": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+            "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^2.0.0",
+                "argue-cli": "^3.1.0"
+            },
+            "bin": {
+                "conventional-commits-parser": "dist/cli/index.js"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
+        "node_modules/@conventional-changelog/template": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+            "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -5877,6 +6248,35 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/@simple-libs/child-process-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
+            "integrity": "sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@simple-libs/stream-utils": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
+        "node_modules/@simple-libs/stream-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@simple-libs/stream-utils/-/stream-utils-2.0.0.tgz",
+            "integrity": "sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
         "node_modules/@simplewebauthn/browser": {
             "version": "13.2.2",
             "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.2.2.tgz",
@@ -7713,6 +8113,19 @@
             "dev": true,
             "license": "Python-2.0"
         },
+        "node_modules/argue-cli": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/argue-cli/-/argue-cli-3.1.0.tgz",
+            "integrity": "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/dangreen"
+            }
+        },
         "node_modules/argv-formatter": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
@@ -8466,6 +8879,19 @@
                 "node": ">=18"
             }
         },
+        "node_modules/conventional-changelog-conventionalcommits": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+            "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@conventional-changelog/template": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=22"
+            }
+        },
         "node_modules/conventional-changelog-writer": {
             "version": "8.2.0",
             "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
@@ -8553,9 +8979,9 @@
             "license": "MIT"
         },
         "node_modules/cosmiconfig": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+            "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8577,6 +9003,24 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/cosmiconfig-typescript-loader": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-6.3.0.tgz",
+            "integrity": "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jiti": "2.6.1"
+            },
+            "engines": {
+                "node": ">=v18"
+            },
+            "peerDependencies": {
+                "@types/node": "*",
+                "cosmiconfig": ">=9",
+                "typescript": ">=5"
             }
         },
         "node_modules/cross-spawn": {
@@ -9117,6 +9561,18 @@
             "devOptional": true,
             "license": "MIT"
         },
+        "node_modules/es-toolkit": {
+            "version": "1.50.0",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+            "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks",
+                "tests/types"
+            ]
+        },
         "node_modules/escalade": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -9444,6 +9900,23 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-builder": {
             "version": "1.1.4",
@@ -9829,6 +10302,32 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/global-directory": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+            "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "6.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/global-directory/node_modules/ini": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+            "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/globals": {

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "devDependencies": {
         "@aws-sdk/client-s3": "^3.1013.0",
         "@cloudflare/workers-types": "^5.20260804.1",
+        "@commitlint/cli": "^21.2.1",
+        "@commitlint/config-conventional": "^21.2.0",
         "@eslint/js": "^9.21.0",
         "@playwright/test": "^1.58.2",
         "@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
## The failure

[Run 31375531519](https://github.com/jlian/wingdex/actions/runs/31375531519) failed with:

```
[semantic-release] The local branch main is behind the remote one, therefore a new version won't be published.
##[error]Could not determine the next iOS release version
```

## Mechanism

`iOS Release` and `Release` share the `release-${{ github.ref_name }}` concurrency group, so they serialize. On the merge of #302:

```
09:38:10  Release triggered on fae9515
09:38:11  iOS Release triggered on fae9515   (same commit, queued behind Release)
09:38:56  Release pushes 44a508c chore(Release): 1.24.0   -> main advances
09:40:09  Release finishes, concurrency slot frees
09:40:30  iOS preflight starts, checkout pinned to fae9515 -> now 1 behind
09:41:17  semantic-release refuses: local branch is behind the remote
```

The concurrency group worked correctly. Waiting is exactly what let `main` advance underneath a pinned checkout. Resolving the ref at execution time picks up the bump the previous workflow just pushed.

## Why it regressed

Fixed once in 8a72195 (March), then undone in two steps, both inside #302:

- `60189c3` added the `release_version` tag path and replaced `ref: ${{ github.ref }}` with a resolver step whose fallback was `GITHUB_SHA`.
- `b8f9dd9` pinned the publish job to `github.sha`, reasoning that a mutable branch ref could archive code other than the triggering commit.

That reasoning is sound in general, but not under this concurrency group, where the commit landing mid-run *is* the version bump this release depends on.

## Change

Both `preflight` and `publish` now select the ref inline:

```yaml
ref: ${{ inputs.release_version && format('refs/tags/ios-v{0}', inputs.release_version) || github.ref }}
```

- **Rebuild an existing release** (`workflow_dispatch` with `release_version`): unchanged, still checks out `refs/tags/ios-v<version>` so the app source matches the shipped version.
- **Normal release**: branch tip, so a queued run sees the version bump.

Choosing at the call site rather than in a resolver step makes the two modes visible where they are used, which is how the fallback got silently reverted last time. Both call sites carry a comment naming the failure mode.

`fetch-depth: 0` and `persist-credentials: false` are preserved. The tooling-restore step still pins `github.sha`, which is correct: it deliberately pulls current CI tooling into an old tag checkout.

## Verification

- YAML parses (`yaml.safe_load`)
- No dangling references to the removed `steps.source` output
- ASCII only, per CONTRIBUTING
- Expression check: `release_version=''` resolves to `github.ref`; `release_version='0.8.0'` resolves to `refs/tags/ios-v0.8.0`. Consistent with the existing `inputs.release_version == ''` guards elsewhere in the file.

Full end-to-end proof requires a real release, since the bug only appears when both workflows trigger on one commit.