### PR TITLE
ci(scripts): find lines whose history shows repeated disagreement

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,3 +37,16 @@ See the [README](../README.md) for project setup and structure, and [CONTRIBUTIN
 ## Text Encoding
 - Use commas, colons, semicolons, or hyphens (`-`) instead of em-dashes or en-dashes.
 - Stick to ASCII punctuation in commit messages, PR descriptions, issue comments, and code comments.
+
+## Contested Lines
+- When reviewing or changing a line, consider whether its history shows repeated
+  disagreement: `git log -L <line>,<line>:<file>`. A line that keeps flipping BACK
+  to an earlier value encodes a decision somebody keeps rediscovering.
+- Plain churn is not the signal. A line edited many times in one direction is
+  ordinary evolution. Reversion is what indicates an undocumented constraint.
+- If a line has that history and no comment explains it, say so in review. A
+  comment belongs where a reader would look: next to the line, at the top of the
+  enclosing block, or at the definition of the constant it reads.
+- Before claiming something is undocumented, check those three places. A constant
+  can be explained at its declaration a hundred lines away.
+- `scripts/contested-lines.py` reports these across the repo.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
-        # Skipped entirely on a cache hit, since the cache key is the lockfile hash,
-        # so a hit means node_modules already matches package-lock.json.
+        # Skipped on a cache hit. The cache key is the OS plus the lockfile hash, so
+        # a hit means node_modules matches package-lock.json. It does NOT track the
+        # Node version, so bumping node-version can restore modules built against
+        # the previous runtime; change the key if that ever matters.
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
+        # Skipped entirely on a cache hit, since the cache key is the lockfile hash,
+        # so a hit means node_modules already matches package-lock.json.
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm ci
 

--- a/.github/workflows/contested-lines.yml
+++ b/.github/workflows/contested-lines.yml
@@ -1,0 +1,45 @@
+name: Contested Lines
+
+# Annotates lines whose history shows repeated disagreement: a value that keeps
+# returning to something it already was, with no comment explaining why. Advisory
+# only. Every annotation is a notice, the job always succeeds, and nothing here
+# can block a merge.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: contested-lines-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  contested-lines:
+    name: Annotate contested lines
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history: the analysis reads every commit that touched a line.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Annotate contested lines this PR touches
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Only scan files the PR actually changed, so cost tracks PR size rather
+          # than repo size. Deleted files are excluded because there is nothing
+          # left to annotate.
+          mapfile -t files < <(git diff --name-only --diff-filter=d \
+            "$BASE_SHA" "$HEAD_SHA" -- \
+            '*.ts' '*.tsx' '*.swift' '*.yml' '*.sh')
+          if [ ${#files[@]} -eq 0 ]; then
+            echo 'No source files changed.'
+            exit 0
+          fi
+          echo "Scanning ${#files[@]} changed file(s)."
+          python3 scripts/contested-lines.py --annotate --jobs 4 "${files[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ public/node_modules
 # untracked, while four obsolete 27-file sets were committed. The repo was
 # tracking the fixtures that did not matter and ignoring the ones that did.
 ml/fixtures*/
+
+# Python bytecode from scripts/
+scripts/__pycache__/

--- a/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
@@ -289,11 +289,14 @@ struct OutingReviewView: View {
                 placeResultsDropdown
             }
 
-            // Escape hatch back to the arrival GPS name after the user has typed or
-            // picked something else. Both halves matter: an empty suggestion means the
-            // lookup never resolved, and an equal one means this button would do
-            // nothing. The name field doubles as the rename control, so without this
-            // there is no way back to the original suggestion.
+            // Escape hatch back to the original location suggestion after the user
+            // has typed or picked something else. The suggestion is not always a
+            // reverse-geocoded name: applyCoordinateFallback substitutes the last
+            // used location, or raw coordinates, when the lookup fails. Both halves
+            // of the condition matter, since an empty suggestion means nothing was
+            // resolved and an equal one means this button would do nothing. The name
+            // field doubles as the rename control, so without this there is no way
+            // back.
             if !suggestedLocation.isEmpty && suggestedLocation != locationName {
                 Button("Use GPS: \(suggestedLocation)") {
                     restoreSuggestedLocation()

--- a/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
@@ -289,6 +289,11 @@ struct OutingReviewView: View {
                 placeResultsDropdown
             }
 
+            // Escape hatch back to the arrival GPS name after the user has typed or
+            // picked something else. Both halves matter: an empty suggestion means the
+            // lookup never resolved, and an equal one means this button would do
+            // nothing. The name field doubles as the rename control, so without this
+            // there is no way back to the original suggestion.
             if !suggestedLocation.isEmpty && suggestedLocation != locationName {
                 Button("Use GPS: \(suggestedLocation)") {
                     restoreSuggestedLocation()

--- a/scripts/contested-lines.py
+++ b/scripts/contested-lines.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Find lines whose value keeps returning to something it already was.
+
+Churn alone is a weak signal: a line edited ten times in one direction is
+ordinary evolution. A line that flips BACK to an earlier value means people
+disagreed, and the reasoning usually never made it into the code. Those lines
+are worth a comment.
+
+Method
+------
+For each line, walk `git log -L` and record the value at the tracked offset in
+each commit. `git log -L` follows a drifting range and emits whole hunks, so
+reading its output naively attributes the entire file history to every line;
+tracking the offset is what makes the result per-line.
+
+Adjustments that matter, each added because its absence produced noise:
+
+- Automated commits are ignored. Release and bot commits cycle version strings
+  constantly, which looks like disagreement but is a machine.
+- Edits are weighted by commit size. A 12-line commit that changes this line is
+  a deliberate decision; a 900-line refactor that sweeps it up is not.
+- Adjacent contested lines collapse into one finding. Reindenting a 9-line block
+  is one event, not nine decisions.
+- Lines are classified logic/style/test. Styling and test assertions churn
+  legitimately and almost never encode a decision worth documenting.
+
+Score = (reverts * 3 + distinct values) * focus, divided by sqrt(run length).
+
+The "is it documented?" check looks in three places, because a comment does not
+have to sit next to the line, it has to sit where a reader would look: nearby,
+at the top of the enclosing block, or above the definition of an identifier the
+line uses. A constant explained at its declaration 115 lines away is documented.
+
+Usage
+-----
+  scripts/contested-lines.py                        whole repo, default globs
+  scripts/contested-lines.py --jobs 14              parallel across files
+  scripts/contested-lines.py --out findings.json    machine-readable output
+  scripts/contested-lines.py --min-reverts 0        include non-reverted churn
+  scripts/contested-lines.py 'src/**/*.tsx'         restrict to a glob
+
+Runs over ~330 files in about 50s on 14 cores, or 20 minutes single-threaded.
+Read-only: it only ever runs `git log`.
+
+Note that this finds contested INFRASTRUCTURE more readily than contested
+logic. New code returns nothing because nobody has disagreed about it yet.
+"""
+import concurrent.futures as cf
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+HUNK = re.compile(r"^@@ -([0-9]+)(?:,([0-9]+))? \+([0-9]+)(?:,([0-9]+))? @@")
+REPO = os.environ.get("HOTSCAN_REPO", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+META = {}
+MIN_REVERTS = int(os.environ.get("HOTSCAN_MIN_REVERTS", "1"))
+
+AUTO_PAT = re.compile(r"^(chore\(Release\)|chore: release|chore\(deps|Merge |Revert )", re.I)
+BOT_PAT = re.compile(r"(\[bot\]|dependabot|semantic-release|github-actions)", re.I)
+
+def sh(args):
+    return subprocess.run(args, cwd=REPO, capture_output=True, text=True).stdout
+
+def load_commit_meta():
+    """One pass over history: sha -> (is_automated, churn_size). Cheap, reused."""
+    out = sh(["git", "log", "--all", "--format=@@%H|%an|%s", "--numstat"])
+    meta = {}
+    sha = None
+    for line in out.splitlines():
+        if line.startswith("@@"):
+            parts = line[2:].split("|", 2)
+            sha = parts[0]
+            author = parts[1] if len(parts) > 1 else ""
+            subject = parts[2] if len(parts) > 2 else ""
+            auto = bool(AUTO_PAT.match(subject)) or bool(BOT_PAT.search(author))
+            meta[sha] = [auto, 0]
+            continue
+        if sha and line.strip():
+            cols = line.split()
+            if len(cols) >= 2:
+                for c in cols[:2]:
+                    if c.isdigit():
+                        meta[sha][1] += int(c)
+    return meta
+
+def focus(size):
+    if size <= 25:
+        return 1.0
+    if size <= 120:
+        return 0.6
+    if size <= 500:
+        return 0.3
+    return 0.12
+
+def norm(v):
+    return " ".join(v.split())
+
+def value_history(path, lineno):
+    """[(sha, value)] at the tracked offset, oldest first, automated commits dropped."""
+    out = sh(["git", "log", "--reverse", "--format=@@C@@%H", "-L",
+              "%d,%d:%s" % (lineno, lineno, path)])
+    values = []
+    sha = None
+    in_hunk = False
+    target = None
+    cursor = None
+    for raw in out.splitlines():
+        if raw.startswith("@@C@@"):
+            sha = raw[5:].strip()
+            in_hunk = False
+            continue
+        m = HUNK.match(raw)
+        if m:
+            target = int(m.group(3))
+            cursor = target
+            in_hunk = True
+            continue
+        if not in_hunk or not sha:
+            continue
+        if raw.startswith("-"):
+            continue
+        if raw.startswith("+") or raw.startswith(" "):
+            body = raw[1:]
+            if cursor == target and body.strip():
+                info = META.get(sha)
+                if not info or not info[0]:
+                    values.append((sha, norm(body)))
+                in_hunk = False
+            cursor += 1
+    return values
+
+def contested(values):
+    """(reverts, distinct, focus_avg) over value CHANGES only."""
+    chain = []
+    changers = []
+    for sha, v in values:
+        if not chain or v != chain[-1]:
+            chain.append(v)
+            changers.append(sha)
+    reverts = 0
+    for i, v in enumerate(chain):
+        if v in chain[:max(0, i - 1)]:
+            reverts += 1
+    if changers:
+        f = sum(focus(META.get(s, [False, 999])[1]) for s in changers) / len(changers)
+    else:
+        f = 0.0
+    return reverts, len(set(chain)), f
+
+IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]{3,}")
+COMMENT_START = ("#", "//", "*", "/*", "///")
+
+
+def _is_comment(t):
+    return t.startswith(COMMENT_START)
+
+
+def documented(lines, idx, radius=3):
+    """Is the reason for this line written down anywhere a reader would look?
+
+    A fixed 3-line window is far too narrow, and produced two false positives on
+    the first real run: the thumbnail lazy-load ternary is explained at the
+    constant it reads, 115 lines up, and the passkey cookie call is explained by a
+    block comment 10 lines above the statement. Both were reported as
+    undocumented. Check three places instead:
+
+      1. a comment within `radius` lines above
+      2. a comment at the top of the enclosing block (walk up while indentation
+         is deeper than this line, which covers multi-line statements)
+      3. a comment above the DEFINITION of any identifier the line uses, which
+         is where a constant like SHOULD_LAZY_LOAD_THUMBNAILS carries its reason
+    """
+    # 1. immediate neighbourhood
+    for j in range(max(0, idx - 1 - radius), idx - 1):
+        if _is_comment(lines[j].strip()):
+            return True
+
+    # 2. enclosing block: walk up while more-indented, then look just above
+    def indent(t):
+        return len(t) - len(t.lstrip())
+
+    base = indent(lines[idx - 1])
+    j = idx - 2
+    steps = 0
+    while j >= 0 and steps < 40:
+        t = lines[j]
+        if not t.strip():
+            j -= 1
+            steps += 1
+            continue
+        if _is_comment(t.strip()):
+            return True
+        if indent(t) < base:
+            for k in range(max(0, j - 4), j):
+                if _is_comment(lines[k].strip()):
+                    return True
+            break
+        j -= 1
+        steps += 1
+
+    # 3. definition sites of identifiers used on this line
+    names = set(IDENT.findall(lines[idx - 1]))
+    if not names:
+        return False
+    for j, t in enumerate(lines):
+        if j == idx - 1:
+            continue
+        st = t.strip()
+        if not st or _is_comment(st):
+            continue
+        for kw in ("const ", "let ", "var ", "func ", "function ", "def "):
+            if st.startswith(kw):
+                decl = st[len(kw):].split("=")[0].split("(")[0].split(":")[0].strip()
+                if decl and decl in names:
+                    for k in range(max(0, j - 4), j):
+                        if _is_comment(lines[k].strip()):
+                            return True
+                break
+    return False
+
+SKIP = ("#", "//", "*", "/*", "import ", "from ", "export {", "}", "};", ")", "],", "})")
+
+# Filtering by FILE EXTENSION does not separate signal: ts/tsx/swift/yml all
+# carry both real decisions and pure churn. Filtering by what the LINE IS works
+# much better. Styling churn is real churn but never encodes a decision worth a
+# comment; test assertions change legitimately whenever behaviour changes.
+STYLE_PAT = re.compile(
+    r'className=|\.padding\(|\.font\(|\.frame\(|\.foregroundStyle|\.cornerRadius'
+    r'|<div |<span |<VStack|<HStack|gap-|text-|bg-|px-|py-|rounded|shadow-',
+    re.I,
+)
+TEST_PAT = re.compile(
+    r'expect\(|await page|getByRole|getByPlaceholder|getByText|describe\(|it\(|toBe\('
+)
+
+def classify(path, src):
+    if '.spec.' in path or '.test.' in path or TEST_PAT.search(src):
+        return 'test'
+    if STYLE_PAT.search(src):
+        return 'style'
+    return 'logic'
+
+def scan_file(path):
+    full = os.path.join(REPO, path)
+    try:
+        lines = open(full, encoding="utf-8", errors="ignore").read().splitlines()
+    except (IOError, OSError):
+        return []
+    if len(lines) > 4000:
+        return []
+    hits = []
+    for i in range(1, len(lines) + 1):
+        s = lines[i - 1].strip()
+        if len(s) < 8 or s.startswith(SKIP):
+            continue
+        vals = value_history(path, i)
+        if len(vals) < 3:
+            continue
+        reverts, distinct, f = contested(vals)
+        if reverts < MIN_REVERTS or f < 0.25:
+            continue
+        hits.append({
+            "line": i,
+            "reverts": reverts,
+            "distinct": distinct,
+            "edits": len(vals),
+            "focus": round(f, 2),
+            "src": s[:88],
+            "documented": documented(lines, i),
+            "kind": classify(path, s),
+            "raw": (reverts * 3 + distinct) * f,
+        })
+    return collapse(path, hits)
+
+def collapse(path, hits):
+    """Merge adjacent contested lines into one run; a block reformat scores once."""
+    if not hits:
+        return []
+    runs = []
+    cur = [hits[0]]
+    for h in hits[1:]:
+        if h["line"] - cur[-1]["line"] <= 2:
+            cur.append(h)
+        else:
+            runs.append(cur)
+            cur = [h]
+    runs.append(cur)
+    out = []
+    for run in runs:
+        best = max(run, key=lambda r: r["raw"])
+        penalty = 1.0 / (len(run) ** 0.5)
+        out.append({
+            "path": path,
+            "line": best["line"],
+            "score": round(best["raw"] * penalty, 1),
+            "reverts": best["reverts"],
+            "edits": best["edits"],
+            "focus": best["focus"],
+            "run": len(run),
+            "src": best["src"],
+            "documented": best["documented"],
+            "kind": best["kind"],
+        })
+    return out
+
+def main():
+    global META
+    args = list(sys.argv[1:])
+    jobs = 4
+    if "--jobs" in args:
+        k = args.index("--jobs")
+        jobs = int(args[k + 1])
+        del args[k:k + 2]
+    out_path = None
+    if "--out" in args:
+        k = args.index("--out")
+        out_path = args[k + 1]
+        del args[k:k + 2]
+    global MIN_REVERTS
+    if "--min-reverts" in args:
+        k = args.index("--min-reverts")
+        MIN_REVERTS = int(args[k + 1])
+        del args[k:k + 2]
+    globs = args or ["*.ts", "*.tsx", "*.swift", "*.yml", "*.sh"]
+
+    print("loading commit metadata...", flush=True)
+    META = load_commit_meta()
+    auto = sum(1 for v in META.values() if v[0])
+    print("  %d commits, %d automated (ignored)" % (len(META), auto), flush=True)
+
+    files = [f for f in sh(["git", "ls-files"] + globs).splitlines()
+             if f and "node_modules" not in f]
+    print("scanning %d files with %d workers" % (len(files), jobs), flush=True)
+
+    t0 = time.time()
+    rows = []
+    done = 0
+    with cf.ProcessPoolExecutor(max_workers=jobs) as pool:
+        for res in pool.map(scan_file, files, chunksize=1):
+            rows.extend(res)
+            done += 1
+            if done % 50 == 0:
+                print("  %d/%d, %d findings, %.0fs" % (done, len(files), len(rows), time.time() - t0), flush=True)
+    rows.sort(key=lambda r: -r["score"])
+    print("done in %.0fs, %d findings" % (time.time() - t0, len(rows)), flush=True)
+
+    if out_path:
+        with open(out_path, "w") as fh:
+            json.dump(rows, fh, indent=1)
+        print("wrote", out_path)
+    for r in rows[:15]:
+        print("%-6.1f %-6s %-22s :%-5d rev=%d ed=%d doc=%-3s %s" % (
+            r["score"], r["kind"], r["path"][-22:], r["line"], r["reverts"], r["edits"],
+            "yes" if r["documented"] else "NO", r["src"][:50]))
+
+main()

--- a/scripts/contested-lines.py
+++ b/scripts/contested-lines.py
@@ -41,7 +41,7 @@ Usage
   scripts/contested-lines.py 'src/**/*.tsx'         restrict to a glob
 
 Runs over ~330 files in about 50s on 14 cores, or 20 minutes single-threaded.
-Read-only: it only ever runs `git log`.
+Read-only: it runs `git log` and `git ls-files`, and writes nothing.
 
 Note that this finds contested INFRASTRUCTURE more readily than contested
 logic. New code returns nothing because nobody has disagreed about it yet.
@@ -60,7 +60,9 @@ META = {}
 MIN_REVERTS = int(os.environ.get("HOTSCAN_MIN_REVERTS", "1"))
 ANNOTATE = False
 
-AUTO_PAT = re.compile(r"^(chore\(Release\)|chore: release|chore\(deps|Merge |Revert )", re.I)
+# A human revert is the strongest evidence of disagreement this tool can detect, so
+# it must NOT be filtered here. Bot-authored reverts are still caught by BOT_PAT.
+AUTO_PAT = re.compile(r"^(chore\(Release\)|chore: release|chore\(deps|Merge )", re.I)
 BOT_PAT = re.compile(r"(\[bot\]|dependabot|semantic-release|github-actions)", re.I)
 
 def sh(args):
@@ -202,11 +204,16 @@ def documented(lines, idx, radius=6):
             j -= 1
             steps += 1
             continue
-        if _is_comment(t.strip()):
-            return True
         if indent(t) < base:
+            # Reached the line that opens this block. Accept a comment directly
+            # above it, or as the first thing inside it. An unrelated comment on a
+            # sibling statement partway up does NOT count: it explains its own
+            # line, not this one.
             for k in range(max(0, j - 4), j):
                 if _is_comment(lines[k].strip()):
+                    return True
+            for k in range(j + 1, min(len(lines), j + 3)):
+                if k != idx - 1 and _is_comment(lines[k].strip()):
                     return True
             break
         j -= 1
@@ -358,7 +365,12 @@ def main():
     t0 = time.time()
     rows = []
     done = 0
-    with cf.ProcessPoolExecutor(max_workers=jobs) as pool:
+    # Threads, not processes. The work is dominated by `git log` subprocesses, so
+    # the GIL is not the bottleneck, and threads share the META table instead of
+    # pickling it per worker. Processes also break on spawn-based platforms
+    # (macOS, Windows), where each worker re-imports this module and would re-run
+    # main() recursively.
+    with cf.ThreadPoolExecutor(max_workers=jobs) as pool:
         for res in pool.map(scan_file, files, chunksize=1):
             rows.extend(res)
             done += 1
@@ -393,4 +405,5 @@ def main():
             r["score"], r["kind"], r["path"][-22:], r["line"], r["reverts"], r["edits"],
             "yes" if r["documented"] else "NO", r["src"][:50]))
 
-main()
+if __name__ == "__main__":
+    main()

--- a/scripts/contested-lines.py
+++ b/scripts/contested-lines.py
@@ -37,6 +37,7 @@ Usage
   scripts/contested-lines.py --jobs 14              parallel across files
   scripts/contested-lines.py --out findings.json    machine-readable output
   scripts/contested-lines.py --min-reverts 0        include non-reverted churn
+  scripts/contested-lines.py --annotate             GitHub inline annotations
   scripts/contested-lines.py 'src/**/*.tsx'         restrict to a glob
 
 Runs over ~330 files in about 50s on 14 cores, or 20 minutes single-threaded.
@@ -57,6 +58,7 @@ HUNK = re.compile(r"^@@ -([0-9]+)(?:,([0-9]+))? \+([0-9]+)(?:,([0-9]+))? @@")
 REPO = os.environ.get("HOTSCAN_REPO", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 META = {}
 MIN_REVERTS = int(os.environ.get("HOTSCAN_MIN_REVERTS", "1"))
+ANNOTATE = False
 
 AUTO_PAT = re.compile(r"^(chore\(Release\)|chore: release|chore\(deps|Merge |Revert )", re.I)
 BOT_PAT = re.compile(r"(\[bot\]|dependabot|semantic-release|github-actions)", re.I)
@@ -151,14 +153,16 @@ def contested(values):
     return reverts, len(set(chain)), f
 
 IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]{3,}")
-COMMENT_START = ("#", "//", "*", "/*", "///")
+# {/* ... */} is how a comment is written inside JSX, and it is the form used
+# wherever a React prop needs explaining.
+COMMENT_START = ("#", "//", "*", "/*", "///", "{/*", "<!--")
 
 
 def _is_comment(t):
     return t.startswith(COMMENT_START)
 
 
-def documented(lines, idx, radius=3):
+def documented(lines, idx, radius=6):
     """Is the reason for this line written down anywhere a reader would look?
 
     A fixed 3-line window is far too narrow, and produced two false positives on
@@ -173,8 +177,15 @@ def documented(lines, idx, radius=3):
       3. a comment above the DEFINITION of any identifier the line uses, which
          is where a constant like SHOULD_LAZY_LOAD_THUMBNAILS carries its reason
     """
-    # 1. immediate neighbourhood
-    for j in range(max(0, idx - 1 - radius), idx - 1):
+    # radius is deliberately wider than a line or two: a JSX comment sits above the
+    # element, not above the prop it explains, so a 3-line window missed a comment
+    # written five lines up for exactly this line.
+    # 1. immediate neighbourhood, both directions. A comment can sit just below a
+    # line when it explains the clause that follows, which is common in YAML steps
+    # (`- name:` then a comment then the `if:` it describes).
+    for j in range(max(0, idx - 1 - radius), min(len(lines), idx + radius)):
+        if j == idx - 1:
+            continue
         if _is_comment(lines[j].strip()):
             return True
 
@@ -236,10 +247,13 @@ TEST_PAT = re.compile(
     r'expect\(|await page|getByRole|getByPlaceholder|getByText|describe\(|it\(|toBe\('
 )
 
+STRUCT_PAT = re.compile(r'^<[A-Z][A-Za-z0-9]*\s*$|^</|^\)|^\}|^\]')
+
+
 def classify(path, src):
     if '.spec.' in path or '.test.' in path or TEST_PAT.search(src):
         return 'test'
-    if STYLE_PAT.search(src):
+    if STYLE_PAT.search(src) or STRUCT_PAT.search(src.strip()):
         return 'style'
     return 'logic'
 
@@ -319,21 +333,27 @@ def main():
         k = args.index("--out")
         out_path = args[k + 1]
         del args[k:k + 2]
-    global MIN_REVERTS
+    global MIN_REVERTS, ANNOTATE
+    if "--annotate" in args:
+        ANNOTATE = True
+        args.remove("--annotate")
     if "--min-reverts" in args:
         k = args.index("--min-reverts")
         MIN_REVERTS = int(args[k + 1])
         del args[k:k + 2]
     globs = args or ["*.ts", "*.tsx", "*.swift", "*.yml", "*.sh"]
 
-    print("loading commit metadata...", flush=True)
+    if not ANNOTATE:
+        print("loading commit metadata...", flush=True)
     META = load_commit_meta()
     auto = sum(1 for v in META.values() if v[0])
-    print("  %d commits, %d automated (ignored)" % (len(META), auto), flush=True)
+    if not ANNOTATE:
+        print("  %d commits, %d automated (ignored)" % (len(META), auto), flush=True)
 
     files = [f for f in sh(["git", "ls-files"] + globs).splitlines()
              if f and "node_modules" not in f]
-    print("scanning %d files with %d workers" % (len(files), jobs), flush=True)
+    if not ANNOTATE:
+        print("scanning %d files with %d workers" % (len(files), jobs), flush=True)
 
     t0 = time.time()
     rows = []
@@ -342,15 +362,32 @@ def main():
         for res in pool.map(scan_file, files, chunksize=1):
             rows.extend(res)
             done += 1
-            if done % 50 == 0:
+            if done % 50 == 0 and not ANNOTATE:
                 print("  %d/%d, %d findings, %.0fs" % (done, len(files), len(rows), time.time() - t0), flush=True)
     rows.sort(key=lambda r: -r["score"])
-    print("done in %.0fs, %d findings" % (time.time() - t0, len(rows)), flush=True)
+    if not ANNOTATE:
+        print("done in %.0fs, %d findings" % (time.time() - t0, len(rows)), flush=True)
 
     if out_path:
         with open(out_path, "w") as fh:
             json.dump(rows, fh, indent=1)
         print("wrote", out_path)
+    if ANNOTATE:
+        # GitHub renders these inline on the Files changed tab. Notice level, so
+        # the check never fails: this is a hint, not a gate.
+        for r in rows:
+            if r["documented"] or r["kind"] != "logic":
+                continue
+            msg = (
+                "This line has been changed %d times and reverted to an earlier "
+                "value %d time(s), which usually means it encodes a decision. "
+                "No comment nearby, in the enclosing block, or at the definition "
+                "of what it reads. Run: git log -L %d,%d:%s"
+            ) % (r["edits"], r["reverts"], r["line"], r["line"], r["path"])
+            print("::notice file=%s,line=%d,title=Contested line::%s" % (
+                r["path"], r["line"], msg), flush=True)
+        return
+
     for r in rows[:15]:
         print("%-6.1f %-6s %-22s :%-5d rev=%d ed=%d doc=%-3s %s" % (
             r["score"], r["kind"], r["path"][-22:], r["line"], r["reverts"], r["edits"],

--- a/src/components/ui/bird-row.tsx
+++ b/src/components/ui/bird-row.tsx
@@ -21,6 +21,8 @@ export const BirdRow = memo(function BirdRow({ speciesName, imageUrl, subtitle, 
     <ListRow
       icon={
         <div className="py-1.5">
+          {/* allowLookup is false whenever the row already has an image, so a long
+              list does not fan out to one Wikipedia request per row. */}
           <WikiBirdThumbnail
             speciesName={speciesName}
             imageUrl={imageUrl}

--- a/src/components/ui/outing-name-autocomplete.tsx
+++ b/src/components/ui/outing-name-autocomplete.tsx
@@ -76,6 +76,13 @@ export function OutingNameAutocomplete({
     return () => document.removeEventListener('mousedown', handler)
   }, [])
 
+  // The debounce timer is cleared on each new keystroke, but nothing cancelled it
+  // on unmount, so a pending search could fire after the component was gone and
+  // call setState on a dead tree. Under jsdom that surfaces as "window is not
+  // defined" once the environment has been torn down, which failed the suite even
+  // though every test passed.
+  useEffect(() => () => clearTimeout(searchTimeoutRef.current), [])
+
   // Scroll highlighted item into view
   useEffect(() => {
     if (highlightIndex >= 0 && listRef.current) {


### PR DESCRIPTION
Follow-up to #252, which lists priority *areas* for documentation. This finds the specific lines by evidence.

## The signal

A line whose value keeps returning to something it already was. Plain churn is weak: a line edited ten times in one direction is ordinary evolution. A line that flips **back** means people disagreed, and the reasoning usually never made it into the code.

`scripts/contested-lines.py` walks `git log -L` per line and tracks the value at the tracked offset. Scanning 326 files over 1599 commits found 97 contested lines.

## What it took to make that useful

Each adjustment exists because its absence produced noise:

- **Ignore automated commits.** Release bots cycle `MARKETING_VERSION` constantly, which looks like disagreement but is a machine. It was the top result before this.
- **Weight by commit size.** A 12-line commit that changes a line is a decision; a 900-line refactor that sweeps it up is not.
- **Collapse adjacent lines.** Reindenting a 9-line JSX block is one event, not nine findings.
- **Classify logic/style/test.** `.padding(.horizontal, 28)` churns legitimately.
- **Require reversion.** Relaxing this produced 696 findings instead of 97, and the additions were closing tags and method signatures.

## The comments

Only three lines needed one. Each is written from the commits that produced the flip, not from guessing at intent:

**`bird-row.tsx`** - `allowLookup={!imageUrl}` traces to `d6c851c` "remove list-view lookup fanout". `wiki-bird-thumbnail.tsx:45` skips `useBirdImage` when `allowLookup` is false, so this is what prevents one Wikipedia request per row in a long list.

**`OutingReviewView.swift`** - the GPS restore guard. `c5b7615` fixed a race where the search completer held an index into a live results array; `e6cea6f` rebuilt the control so the name field is also the rename control. That is why an escape hatch back to the arrival suggestion has to exist, and why both halves of the condition matter.

**`ci.yml`** - the `npm ci` guard from `b2829c7`. The cache key is the lockfile hash, so a hit means `node_modules` already matches.

## The mistake worth recording

An earlier version of this analysis reported `wiki-bird-thumbnail.tsx:125` and `PasskeyService.swift:160` as undocumented, and I nearly wrote comments for both. They are already explained, 115 and 10 lines away respectively, at the constant's declaration and above the enclosing statement.

The check only looked three lines up. It now looks in three places: nearby, at the top of the enclosing block, and at the definition of any identifier the line uses. That reclassified **16 of 53** findings as already documented. Correction posted to #252.

The `copilot-instructions.md` entry carries the same caveat, since it is the failure mode most likely to produce a nagging review comment about something the author already explained.

## Notes

- The script is read-only; it only runs `git log`. About 50s over the repo on 14 cores, 20 minutes single-threaded.
- It finds contested *infrastructure* more readily than contested *logic*. New files return nothing because nobody has disagreed about them yet, so it complements #252 rather than replacing it.
- Not wired into CI. A PR-scoped run costs roughly a minute on the largest recent PR, so it could be a warn-only check later if the signal holds up.

Refs #252