### PR TITLE
test(iOS): fail instead of skipping when CI has no local Worker

### DIFF
--- a/ios/WingDexUITests/BirdIdFlowUITests.swift
+++ b/ios/WingDexUITests/BirdIdFlowUITests.swift
@@ -93,12 +93,28 @@ final class BirdIdFlowUITests: XCTestCase {
         return app
     }
 
-    private func localWorkerIsAvailable() async -> Bool {
+    /// Why the local Worker could not be reached, or nil when it is healthy.
+    ///
+    /// Returns the reason rather than a bool so CI can put it in the failure
+    /// message. A bare false told us nothing on 2026-08-10, when this test skipped
+    /// because the simulator had not finished booting and the run stayed green.
+    private func localWorkerUnavailableReason() async -> String? {
         let url = localWorkerURL.appendingPathComponent("api/health")
-        guard let (data, response) = try? await URLSession.shared.data(from: url),
-              let http = response as? HTTPURLResponse
-        else { return false }
-        return (200...299).contains(http.statusCode) && !data.isEmpty
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let http = response as? HTTPURLResponse else {
+                return "\(url) returned a non-HTTP response"
+            }
+            guard (200...299).contains(http.statusCode) else {
+                return "\(url) returned HTTP \(http.statusCode)"
+            }
+            guard !data.isEmpty else {
+                return "\(url) returned an empty body"
+            }
+            return nil
+        } catch {
+            return "\(url) is unreachable: \(error.localizedDescription)"
+        }
     }
 
     func testKnownPhotoReachesConfirmStepWithTheRightSpecies() {
@@ -162,11 +178,18 @@ final class BirdIdFlowUITests: XCTestCase {
     }
 
     func testSubmittedPlaceSearchSelectsNormalizedResult() async throws {
-        let localWorkerAvailable = await localWorkerIsAvailable()
-        try XCTSkipUnless(
-            localWorkerAvailable,
-            "Requires the current local WingDex Worker and Geoapify access"
-        )
+        if let reason = await localWorkerUnavailableReason() {
+            // Skipping is right on a laptop with no Worker running. It is wrong in
+            // CI, which provisions one on purpose: a skip there means the harness
+            // is broken, and reporting it as success is how the 2026-08-10 release
+            // failure went unnoticed until it reached the release job.
+            #if CI
+            XCTFail("Local Worker is required in CI but was not reachable. \(reason)")
+            return
+            #else
+            throw XCTSkip("Requires the current local WingDex Worker and Geoapify access. \(reason)")
+            #endif
+        }
         let app = launchApp(extraEnvironment: [
             "API_BASE_URL": localWorkerURL.absoluteString,
         ])


### PR DESCRIPTION
Last open item from step 2 of #314.

## Why

`testSubmittedPlaceSearchSelectsNormalizedResult` skips when the local Worker is unreachable. That is correct on a laptop with nothing running. It is wrong in CI, which provisions a Worker on purpose, so a skip there means the harness is broken.

It hid the failure that opened #314. On 2026-08-10 the release job started testing against a simulator that had not finished booting, so:

- the `URLSession` health check failed, and this test skipped **silently**
- five other tests then died on `waitForExistence(timeout: 120)` waiting for a screen that never rendered
- the run burned 23 minutes and reported `1 test skipped`

The skip was the earliest available signal that the environment was broken, and it presented as success.

## What changes

Skip locally, fail under `CI`:

```swift
if let reason = await localWorkerUnavailableReason() {
    #if CI
    XCTFail("Local Worker is required in CI but was not reachable. \(reason)")
    return
    #else
    throw XCTSkip("Requires the current local WingDex Worker and Geoapify access. \(reason)")
    #endif
}
```

Both iOS workflows already define `CI` through `SWIFT_ACTIVE_COMPILATION_CONDITIONS`, and the file already uses `#if CI` to pick the Worker URL, so this reuses an existing mechanism rather than adding one.

The health check now returns the reason instead of a bool, so a failure says which of these happened: unreachable, non-HTTP response, an HTTP status, or an empty body. A bare `false` is what made the original diagnosis slow.

## Ordering

Worth doing now rather than before #315. That PR fixed the boot race by creating a simulator and blocking on `bootstatus`, and the release that followed passed with **zero** skips in the UI suite. Landing this first would have turned a silent skip into a red PR on every run.

## Not covered

The seven fixture-gated skips in the unit tests (`BirdIDParityTests`, `BirdIdEngineTests`, `CLIPPreprocessParityTests`, `BirdIdAccuracyTests`) are a different case and should stay skips: they need files that are deliberately not shipped to a runner. That those account for 9 of 13 skipped unit tests on a green PR is a separate problem, noted under step 3 in #314.

Refs #314