### PR TITLE
fix(iOS): dismiss keyboard before location suggestions

### DIFF
--- a/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
@@ -401,6 +401,7 @@ struct OutingReviewView: View {
     private func showNearbyPlaces() {
         guard !nearbyPlaces.isEmpty else { return }
         clearSearchResults()
+        isLocationFieldFocused = false
         isShowingPlaceResults = true
     }
 
@@ -572,6 +573,7 @@ struct OutingReviewView: View {
         placeSearchFailed = false
         placeResults = []
         searchedQuery = nil
+        isLocationFieldFocused = false
         isShowingPlaceResults = true
         placeSearchTask = Task {
             defer {

--- a/ios/WingDexUITests/BirdIdFlowUITests.swift
+++ b/ios/WingDexUITests/BirdIdFlowUITests.swift
@@ -232,6 +232,43 @@ final class BirdIdFlowUITests: XCTestCase {
         )
     }
 
+    func testFocusedEmptyLocationShowsNearbyPlacesWithoutKeyboard() async throws {
+        if let reason = await localWorkerUnavailableReason() {
+            #if CI
+            XCTFail("Local Worker is required in CI but was not reachable. \(reason)")
+            return
+            #else
+            throw XCTSkip("Requires the current local WingDex Worker and Geoapify access. \(reason)")
+            #endif
+        }
+        let app = launchApp(extraEnvironment: [
+            "API_BASE_URL": localWorkerURL.absoluteString,
+        ])
+        let continueButton = app.buttons["Continue"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 120))
+        XCTAssertTrue(waitUntil(timeout: 15) { continueButton.isHittable })
+
+        startNewOuting(in: app)
+        let locationName = app.textFields["outing.locationName"]
+        XCTAssertTrue(locationName.waitForExistence(timeout: 15))
+        XCTAssertTrue(scrollUntilVisible(locationName, in: app))
+
+        locationName.tap()
+        app.buttons["outing.locationClear"].tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5))
+        app.buttons["outing.locationSearchSubmit"].tap()
+
+        let firstResult = app.buttons.matching(identifier: "outing.locationResult").firstMatch
+        XCTAssertTrue(firstResult.waitForExistence(timeout: 30), "Nearby place suggestions did not appear")
+        XCTAssertTrue(
+            waitUntil(timeout: 5) { !app.keyboards.firstMatch.exists },
+            "The keyboard remained active behind the nearby places popover"
+        )
+        XCTAssertTrue(firstResult.isHittable, "Nearby place suggestions were not interactive")
+        firstResult.tap()
+        XCTAssertFalse(locationValue(locationName).isEmpty, "Tapping a nearby place did not set the location name")
+    }
+
     func testGeocodingFailureFallsBackToCoordinatesAndAllowsManualEntry() {
         let app = launchApp(extraArguments: [
             "--ui-test-geocoding-failure",


### PR DESCRIPTION
## Summary

- Dismiss location-field focus before presenting nearby or submitted location suggestions.
- Add a UI regression for focus, clear, and tap search that verifies the keyboard closes and nearby results remain interactive.

## Why

The results popover could be presented while its `TextField` still owned keyboard focus. On affected iOS builds, device logs showed repeated keyboard prediction layout and rendering churn after those states overlapped, followed by jetsam termination for memory pressure. Resigning focus before presentation removes that conflicting UI state.

## Verification

- Xcode Production build
- `BirdIdFlowUITests/testFocusedEmptyLocationShowsNearbyPlacesWithoutKeyboard()`
- `BirdIdFlowUITests/testSubmittedPlaceSearchSelectsNormalizedResult()`
- `npm run check` (690 tests)