### PR TITLE
ci(iOS): rebuild test and release workflows

### DIFF
--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -198,12 +198,8 @@ jobs:
           persist-credentials: false
 
       - name: Install XcodeGen
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: '1'
         run: |
-          command -v xcodegen > /dev/null || brew install xcodegen
-          command -v xcbeautify > /dev/null || brew install xcbeautify
-          xcodegen --version
+          ios/scripts/install-xcodegen.sh
           xcbeautify --version
 
       - name: Apply release version locally

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -198,15 +198,17 @@ jobs:
           persist-credentials: false
 
       - name: Install XcodeGen
-        run: brew install xcodegen xcbeautify
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: '1'
+        run: |
+          command -v xcodegen > /dev/null || brew install xcodegen
+          command -v xcbeautify > /dev/null || brew install xcbeautify
+          xcodegen --version
+          xcbeautify --version
 
       - name: Apply release version locally
         working-directory: ios
         run: scripts/bump-version.sh set "${{ needs.check.outputs.release_version }}" --quiet
-
-      - name: Resolve SPM dependencies
-        working-directory: ios
-        run: xcodebuild -resolvePackageDependencies -project WingDex.xcodeproj -scheme Production -onlyUsePackageVersionsFromResolvedFile
 
       - name: Write App Store Connect API key
         run: |

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -1,24 +1,19 @@
 name: iOS Release
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'ios/**'
-      - 'openapi.yaml'
-  workflow_run:
-    workflows: [Release]
-    types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
+      source_sha:
+        description: 'Exact deployed commit to archive'
+        type: string
+        required: false
       dry_run:
         description: 'Validate archive and export without publishing or uploading'
         type: boolean
         default: false
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  group: ${{ inputs.dry_run && format('ios-release-dry-run-{0}', github.run_id) || 'ios-release-main' }}
   cancel-in-progress: false
 
 permissions:
@@ -36,25 +31,64 @@ jobs:
       release_version: ${{ steps.version.outputs.release_version }}
       should_release: ${{ steps.diff.outputs.has_changes }}
       source_sha: ${{ steps.source_sha.outputs.sha }}
+      check_sha: ${{ steps.source_sha.outputs.check_sha }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ inputs.source_sha || github.sha }}
           fetch-depth: 0
 
-      - name: Record release source commit
+      - name: Resolve release source commit
         id: source_sha
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+          SOURCE_SHA=$(git rev-parse HEAD)
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "is_current=true" >> "$GITHUB_OUTPUT"
+          else
+            git fetch origin refs/heads/main:refs/remotes/origin/main
+            REMOTE_SHA=$(git rev-parse refs/remotes/origin/main)
+            if [ "$SOURCE_SHA" != "$REMOTE_SHA" ]; then
+              echo "Source $SOURCE_SHA was superseded by $REMOTE_SHA; a newer Release run will dispatch it"
+              echo "is_current=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_current=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          CHECK_SHA=$(git log -1 --format=%H "$SOURCE_SHA" -- \
+            ios openapi.yaml functions migrations \
+            .github/workflows/ios.yml .github/workflows/ios-release.yml \
+            .github/workflows/release.yml)
+          if [ -z "$CHECK_SHA" ]; then
+            CHECK_SHA="$SOURCE_SHA"
+          fi
+
+          {
+            echo "sha=$SOURCE_SHA"
+            echo "check_sha=$CHECK_SHA"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check for iOS-relevant changes since last tag
         id: diff
+        env:
+          SOURCE_IS_CURRENT: ${{ steps.source_sha.outputs.is_current }}
         run: |
+          if [ "$SOURCE_IS_CURRENT" != "true" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           LAST_TAG=$(git tag --list 'ios-v*' --sort=-v:refname | head -1)
           if [ -z "$LAST_TAG" ]; then
             echo "No previous ios-v tag found - first release"
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
-            CHANGED=$(git diff --name-only "$LAST_TAG"..HEAD -- ios/ openapi.yaml ios/.releaserc.json .github/workflows/ios-release.yml)
+            CHANGED=$(git diff --name-only "$LAST_TAG"..HEAD -- \
+              ios/ openapi.yaml ios/.releaserc.json \
+              .github/workflows/ios.yml .github/workflows/ios-release.yml \
+              .github/workflows/release.yml)
             if [ -n "$CHANGED" ]; then
               echo "iOS-relevant changes found since $LAST_TAG"
               echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -107,6 +141,7 @@ jobs:
         if: steps.version.outputs.has_release == 'true' && inputs.dry_run != true
         env:
           CHECK_NAME: Build & Test (iOS Simulator)
+          CHECK_SHA: ${{ steps.source_sha.outputs.check_sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
         run: |
@@ -118,12 +153,13 @@ jobs:
                 '[.check_runs[] | select(.name == $name)] | (.[0].conclusion // "")'
           }
 
-          TESTED_SHA="$SOURCE_SHA"
-          CONCLUSION=$(conclusion_for "$SOURCE_SHA")
-          PR=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA/pulls" --jq '.[0].number // empty')
+          CONCLUSION=$(conclusion_for "$CHECK_SHA")
+          PR=$(gh api "repos/$GITHUB_REPOSITORY/commits/$CHECK_SHA/pulls" --jq '.[0].number // empty')
+
+          TESTED_SHA="$CHECK_SHA"
 
           if [ "$CONCLUSION" != "success" ] && [ -n "$PR" ]; then
-            TESTED_SHA=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA/pulls" --jq '.[0].head.sha // empty')
+            TESTED_SHA=$(gh api "repos/$GITHUB_REPOSITORY/commits/$CHECK_SHA/pulls" --jq '.[0].head.sha // empty')
             CONCLUSION=$(conclusion_for "$TESTED_SHA")
           fi
 
@@ -138,14 +174,17 @@ jobs:
           # without rebasing onto other iOS changes releases a combination nothing ran.
           if [ "$TESTED_SHA" != "$SOURCE_SHA" ] && [ -n "$PR" ]; then
             git fetch --no-tags --quiet origin "refs/pull/$PR/head"
-            if ! git diff --quiet FETCH_HEAD "$SOURCE_SHA" -- ios openapi.yaml functions migrations; then
+            if ! git diff --quiet FETCH_HEAD "$SOURCE_SHA" -- \
+              ios openapi.yaml functions migrations \
+              .github/workflows/ios.yml .github/workflows/ios-release.yml \
+              .github/workflows/release.yml; then
               echo "::warning::iOS paths changed between tested commit $TESTED_SHA and $SOURCE_SHA; this combination was never tested together"
               echo "- :warning: iOS paths drifted since \`$TESTED_SHA\`" >> "$GITHUB_STEP_SUMMARY"
             fi
           fi
 
   preflight:
-    name: Archive, Export & Publish
+    name: Archive & Export
     needs: check
     if: needs.check.outputs.should_release == 'true' && needs.check.outputs.has_release == 'true'
     runs-on: macos-26
@@ -217,7 +256,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: iOS-release-diagnostics
+          name: iOS-release-diagnostics-attempt-${{ github.run_attempt }}
           path: ios/build/logs/
           retention-days: 7
 
@@ -230,6 +269,18 @@ jobs:
             ios/build/archive-inspection/
             ios/build/WingDex.xcarchive/dSYMs/
           if-no-files-found: error
+          overwrite: true
+          retention-days: 7
+
+      - name: Upload generated release files
+        uses: actions/upload-artifact@v6
+        with:
+          name: WingDex-release-files-${{ needs.check.outputs.release_version }}
+          path: |
+            ios/project.yml
+            ios/WingDex.xcodeproj/project.pbxproj
+          if-no-files-found: error
+          overwrite: true
           retention-days: 7
 
       # Runners start with an empty keychain, so -allowProvisioningUpdates mints a fresh
@@ -301,44 +352,119 @@ jobs:
               core.setFailed(`${failed} of ${stale.length} certificate(s) could not be revoked`);
             }
 
+      - name: Clean up API key
+        if: always()
+        run: rm -rf ~/.appstoreconnect
+
       - name: Validation summary
         run: |
           echo "### Validated iOS v${{ needs.check.outputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "Signed archive inspection, dSYM matching, and App Store export succeeded before publication." >> "$GITHUB_STEP_SUMMARY"
 
+  publish:
+    name: Publish release
+    needs: [check, preflight]
+    if: needs.check.outputs.should_release == 'true' && needs.check.outputs.has_release == 'true' && inputs.dry_run != true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.check.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
       - uses: actions/setup-node@v6
-        if: inputs.dry_run != true
         with:
           node-version: 24
           cache: npm
 
       - name: Install npm dependencies
-        if: inputs.dry_run != true
         run: npm ci
 
-      - name: Verify release source is still current
-        if: inputs.dry_run != true
+      - name: Check publication state
+        id: publication
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.check.outputs.release_version }}
           SOURCE_SHA: ${{ needs.check.outputs.source_sha }}
         run: |
-          git fetch origin refs/heads/main:refs/remotes/origin/main
+          set -euo pipefail
+          TAG="ios-v${RELEASE_VERSION}"
+          git fetch origin refs/heads/main:refs/remotes/origin/main --tags
           REMOTE_SHA=$(git rev-parse refs/remotes/origin/main)
-          if [ "$REMOTE_SHA" != "$SOURCE_SHA" ]; then
-            echo "::error::main advanced from $SOURCE_SHA to $REMOTE_SHA while the archive was built"
+          if git rev-parse "refs/tags/$TAG" > /dev/null 2>&1; then
+            RELEASE_SHA=$(git rev-parse "${TAG}^{commit}")
+            if [ "$(git rev-parse "${RELEASE_SHA}^")" != "$SOURCE_SHA" ] \
+              || ! git merge-base --is-ancestor "$RELEASE_SHA" "$REMOTE_SHA"; then
+              echo "::error::$TAG is not a release child of $SOURCE_SHA on main"
+              exit 1
+            fi
+            git checkout --detach "$RELEASE_SHA"
+            if gh release view "$TAG" > /dev/null 2>&1; then
+              STATE=complete
+            else
+              STATE=tag
+            fi
+          elif [ "$REMOTE_SHA" = "$SOURCE_SHA" ]; then
+            STATE=source
+          elif git merge-base --is-ancestor "$SOURCE_SHA" "$REMOTE_SHA"; then
+            RELEASE_SHA=$(git rev-list --ancestry-path --reverse "$SOURCE_SHA..$REMOTE_SHA" | head -1)
+            read -r -a PARENTS <<< "$(git show -s --format=%P "$RELEASE_SHA")"
+            AUTHOR_EMAIL=$(git show -s --format=%ae "$RELEASE_SHA")
+            SUBJECT=$(git show -s --format=%s "$RELEASE_SHA")
+            UNEXPECTED=$(git diff --name-only "$SOURCE_SHA" "$RELEASE_SHA" \
+              | grep -Ev '^(ios/project\.yml|ios/WingDex\.xcodeproj/project\.pbxproj)$' || true)
+            if [ "${#PARENTS[@]}" -ne 1 ] \
+              || [ "${PARENTS[0]}" != "$SOURCE_SHA" ] \
+              || [ "$AUTHOR_EMAIL" != "semantic-release-bot@martynus.net" ] \
+              || [ "$SUBJECT" != "chore(ios-release): $RELEASE_VERSION" ] \
+              || [ -n "$UNEXPECTED" ]; then
+              echo "::error::No recoverable release commit follows $SOURCE_SHA"
+              exit 1
+            fi
+            git checkout --detach "$RELEASE_SHA"
+            STATE=commit
+          else
+            echo "::error::$SOURCE_SHA is not an ancestor of current main $REMOTE_SHA"
             exit 1
           fi
-          git checkout -B main "$SOURCE_SHA"
-          git branch --set-upstream-to=origin/main main
+          echo "state=$STATE" >> "$GITHUB_OUTPUT"
+
+          if [ "$STATE" = "source" ]; then
+            git checkout -B main "$SOURCE_SHA"
+            git branch --set-upstream-to=origin/main main
+          fi
+
+      - name: Download generated release files
+        if: steps.publication.outputs.state == 'source'
+        uses: actions/download-artifact@v7
+        with:
+          name: WingDex-release-files-${{ needs.check.outputs.release_version }}
+          path: ios
 
       - name: Publish semantic release
-        if: inputs.dry_run != true
+        if: steps.publication.outputs.state == 'source'
         working-directory: ios
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
+      - name: Repair partial publication
+        if: steps.publication.outputs.state == 'commit' || steps.publication.outputs.state == 'tag'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_STATE: ${{ steps.publication.outputs.state }}
+          RELEASE_VERSION: ${{ needs.check.outputs.release_version }}
+        run: |
+          TAG="ios-v${RELEASE_VERSION}"
+          if [ "$RELEASE_STATE" = "commit" ]; then
+            git tag "$TAG" HEAD
+            git push origin "$TAG"
+          fi
+          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
+
       - name: Verify published release
-        if: inputs.dry_run != true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ needs.check.outputs.release_version }}
@@ -349,14 +475,14 @@ jobs:
           TAG_SHA=$(git rev-parse "${TAG}^{commit}")
           TAG_PARENT_SHA=$(git rev-parse "${TAG_SHA}^")
           REMOTE_SHA=$(git rev-parse refs/remotes/origin/main)
-          if [ "$TAG_PARENT_SHA" != "$SOURCE_SHA" ] || [ "$TAG_SHA" != "$REMOTE_SHA" ]; then
-            echo "::error::$TAG does not identify a release commit directly after the archived source"
+          if [ "$TAG_PARENT_SHA" != "$SOURCE_SHA" ] \
+            || ! git merge-base --is-ancestor "$TAG_SHA" "$REMOTE_SHA"; then
+            echo "::error::$TAG is not a release child of the archived source on main"
             exit 1
           fi
           gh release view "$TAG" > /dev/null
 
       - name: Mark pre-1.0 releases as prerelease
-        if: inputs.dry_run != true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -366,21 +492,132 @@ jobs:
             gh release edit "ios-v${VERSION}" --prerelease
           fi
 
-      - name: Upload to TestFlight
-        if: inputs.dry_run != true
+  upload:
+    name: Upload to TestFlight
+    needs: [check, preflight, publish]
+    if: needs.check.outputs.should_release == 'true' && needs.check.outputs.has_release == 'true' && inputs.dry_run != true
+    runs-on: macos-26
+    timeout-minutes: 15
+    steps:
+      - name: Download validated IPA artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: WingDex-${{ needs.check.outputs.release_version }}
+          path: build
+
+      - name: Write App Store Connect API key
         run: |
-          xcrun altool --upload-app \
-            --type ios \
-            --file ios/build/export/WingDex.ipa \
-            --apiKey "${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}" \
-            --apiIssuer "${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}"
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
+
+      - name: Read IPA version
+        id: ipa
+        run: |
+          TMP=$(mktemp -d)
+          unzip -q build/export/WingDex.ipa 'Payload/WingDex.app/Info.plist' -d "$TMP"
+          PLIST="$TMP/Payload/WingDex.app/Info.plist"
+          echo "version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$PLIST")" >> "$GITHUB_OUTPUT"
+          echo "build=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$PLIST")" >> "$GITHUB_OUTPUT"
+          rm -rf "$TMP"
+
+      - name: Upload to TestFlight
+        uses: actions/github-script@v9
+        env:
+          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+          BUILD_NUMBER: ${{ steps.ipa.outputs.build }}
+          MARKETING_VERSION: ${{ steps.ipa.outputs.version }}
+        with:
+          script: |
+            const crypto = require('crypto');
+
+            const privateKey = Buffer.from(process.env.ASC_PRIVATE_KEY, 'base64').toString('utf8');
+            const b64 = (value) => Buffer.from(JSON.stringify(value)).toString('base64url');
+
+            function authorizationToken() {
+              const now = Math.floor(Date.now() / 1000);
+              const signingInput = [
+                b64({ alg: 'ES256', kid: process.env.ASC_KEY_ID, typ: 'JWT' }),
+                b64({ iss: process.env.ASC_ISSUER_ID, iat: now, exp: now + 600, aud: 'appstoreconnect-v1' }),
+              ].join('.');
+              const signature = crypto.sign('sha256', Buffer.from(signingInput), {
+                key: crypto.createPrivateKey(privateKey),
+                dsaEncoding: 'ieee-p1363',
+              });
+              return `${signingInput}.${signature.toString('base64url')}`;
+            }
+
+            async function asc(path, params) {
+              const url = new URL(`https://api.appstoreconnect.apple.com${path}`);
+              for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+              for (let attempt = 1; attempt <= 3; attempt += 1) {
+                const response = await fetch(url, {
+                  headers: { Authorization: `Bearer ${authorizationToken()}` },
+                });
+                if (response.ok) return response.json();
+                const body = await response.text();
+                if (attempt < 3 && (response.status === 429 || response.status >= 500)) {
+                  await new Promise((resolve) => setTimeout(resolve, 5_000));
+                  continue;
+                }
+                throw new Error(`GET ${url.pathname} -> ${response.status} ${body}`);
+              }
+              throw new Error(`GET ${url.pathname} exhausted retries`);
+            }
+
+            const apps = await asc('/v1/apps', {
+              'filter[bundleId]': 'app.wingdex',
+              'fields[apps]': 'bundleId',
+              limit: '1',
+            });
+            if (apps.data.length !== 1) throw new Error('Could not resolve app.wingdex in App Store Connect');
+            const appID = apps.data[0].id;
+
+            async function buildExists() {
+              const builds = await asc('/v1/builds', {
+                'filter[app]': appID,
+                'filter[version]': process.env.BUILD_NUMBER,
+                'filter[preReleaseVersion.version]': process.env.MARKETING_VERSION,
+                'filter[preReleaseVersion.platform]': 'IOS',
+                'fields[builds]': 'version,processingState,uploadedDate',
+                limit: '2',
+              });
+              return builds.data.length > 0;
+            }
+
+            if (await buildExists()) {
+              core.info(`TestFlight already has ${process.env.MARKETING_VERSION} (${process.env.BUILD_NUMBER})`);
+              return;
+            }
+
+            const exitCode = await exec.exec('xcrun', [
+              'altool', '--upload-app',
+              '--type', 'ios',
+              '--file', 'build/export/WingDex.ipa',
+              '--apiKey', process.env.ASC_KEY_ID,
+              '--apiIssuer', process.env.ASC_ISSUER_ID,
+            ], { ignoreReturnCode: true });
+            if (exitCode === 0) return;
+
+            for (let attempt = 1; attempt <= 8; attempt += 1) {
+              await new Promise((resolve) => setTimeout(resolve, 15_000));
+              try {
+                if (await buildExists()) {
+                  core.info('The upload reached App Store Connect despite the altool failure');
+                  return;
+                }
+              } catch (error) {
+                core.warning(`Could not check upload state on attempt ${attempt}: ${error.message}`);
+              }
+            }
+            core.setFailed(`altool exited ${exitCode} and the build did not appear in App Store Connect`);
 
       - name: Clean up API key
         if: always()
         run: rm -rf ~/.appstoreconnect
 
       - name: Summary
-        if: inputs.dry_run != true
         run: |
           echo "### iOS Release v${{ needs.check.outputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "Published and uploaded to TestFlight." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -281,9 +281,8 @@ jobs:
           overwrite: true
           retention-days: 7
 
-      # Runners start with an empty keychain, so -allowProvisioningUpdates mints a fresh
-      # development certificate every run. Left alone they pile up until the account cap
-      # is hit. Their private keys die with the runner, so revoking them is always safe.
+      # Match server certificates to this runner's local signing identities so
+      # overlapping dry runs cannot revoke each other's credentials.
       - name: Revoke CI-created signing certificates
         if: always()
         continue-on-error: true
@@ -328,16 +327,34 @@ jobs:
 
             // Xcode names every certificate it creates through the API "Created via API".
             const REVOCABLE = new Set(['DEVELOPMENT', 'IOS_DEVELOPMENT', 'MAC_APP_DEVELOPMENT']);
-            const { data } = await asc('/v1/certificates?limit=200');
-            const stale = data.filter(
-              (c) => c.attributes.displayName === 'Created via API' && REVOCABLE.has(c.attributes.certificateType),
+            const identities = await exec.getExecOutput(
+              'security',
+              ['find-identity', '-v', '-p', 'codesigning'],
+              { ignoreReturnCode: true, silent: true },
             );
+            const localFingerprints = new Set(
+              Array.from(identities.stdout.matchAll(/\b([0-9A-F]{40})\b/g), (match) => match[1]),
+            );
+            const { data } = await asc('/v1/certificates?limit=200');
+            const owned = data.filter((certificate) => {
+              const attributes = certificate.attributes;
+              if (attributes.displayName !== 'Created via API' || !REVOCABLE.has(attributes.certificateType)) {
+                return false;
+              }
+              if (typeof attributes.certificateContent !== 'string') return false;
+              const fingerprint = crypto
+                .createHash('sha1')
+                .update(Buffer.from(attributes.certificateContent, 'base64'))
+                .digest('hex')
+                .toUpperCase();
+              return localFingerprints.has(fingerprint);
+            });
 
-            core.info(`${data.length} certificate(s) on the account, ${stale.length} CI-created`);
+            core.info(`${data.length} certificate(s) on the account, ${owned.length} owned by this runner`);
 
             // Best effort per certificate: one failure must not strand the rest.
             let failed = 0;
-            for (const cert of stale) {
+            for (const cert of owned) {
               try {
                 await asc(`/v1/certificates/${cert.id}`, 'DELETE');
                 core.info(`Revoked ${cert.attributes.certificateType} ${cert.id} (expiry ${cert.attributes.expirationDate})`);
@@ -347,7 +364,7 @@ jobs:
               }
             }
             if (failed) {
-              core.setFailed(`${failed} of ${stale.length} certificate(s) could not be revoked`);
+              core.setFailed(`${failed} of ${owned.length} certificate(s) could not be revoked`);
             }
 
       - name: Clean up API key
@@ -579,7 +596,7 @@ jobs:
             if (apps.data.length !== 1) throw new Error('Could not resolve app.wingdex in App Store Connect');
             const appID = apps.data[0].id;
 
-            async function buildExists() {
+            async function buildProcessingState() {
               const versions = await asc('/v1/preReleaseVersions', {
                 'filter[app]': appID,
                 'filter[version]': process.env.MARKETING_VERSION,
@@ -587,7 +604,7 @@ jobs:
                 'fields[preReleaseVersions]': 'version,platform',
                 limit: '2',
               });
-              if (versions.data.length === 0) return false;
+              if (versions.data.length === 0) return null;
               if (versions.data.length !== 1) {
                 throw new Error(`Expected one iOS prerelease version for ${process.env.MARKETING_VERSION}`);
               }
@@ -598,11 +615,23 @@ jobs:
                 'fields[builds]': 'version,processingState,uploadedDate',
                 limit: '2',
               });
-              return builds.data.length > 0;
+              if (builds.data.length === 0) return null;
+              if (builds.data.length !== 1) {
+                throw new Error(`Expected one build ${process.env.BUILD_NUMBER} for ${process.env.MARKETING_VERSION}`);
+              }
+              const state = builds.data[0].attributes.processingState;
+              if (!['PROCESSING', 'VALID', 'FAILED', 'INVALID'].includes(state)) {
+                throw new Error(`Unknown App Store Connect build processing state: ${state}`);
+              }
+              return state;
             }
 
-            if (await buildExists()) {
-              core.info(`TestFlight already has ${process.env.MARKETING_VERSION} (${process.env.BUILD_NUMBER})`);
+            const existingState = await buildProcessingState();
+            if (existingState === 'FAILED' || existingState === 'INVALID') {
+              throw new Error(`TestFlight rejected ${process.env.MARKETING_VERSION} (${process.env.BUILD_NUMBER}): ${existingState}`);
+            }
+            if (existingState === 'PROCESSING' || existingState === 'VALID') {
+              core.info(`TestFlight already has ${process.env.MARKETING_VERSION} (${process.env.BUILD_NUMBER}) in state ${existingState}`);
               return;
             }
 
@@ -618,8 +647,13 @@ jobs:
             for (let attempt = 1; attempt <= 8; attempt += 1) {
               await new Promise((resolve) => setTimeout(resolve, 15_000));
               try {
-                if (await buildExists()) {
-                  core.info('The upload reached App Store Connect despite the altool failure');
+                const state = await buildProcessingState();
+                if (state === 'FAILED' || state === 'INVALID') {
+                  core.setFailed(`TestFlight rejected the uploaded build: ${state}`);
+                  return;
+                }
+                if (state === 'PROCESSING' || state === 'VALID') {
+                  core.info(`The upload reached App Store Connect in state ${state} despite the altool failure`);
                   return;
                 }
               } catch (error) {

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -451,14 +451,21 @@ jobs:
       - name: Repair partial publication
         if: steps.publication.outputs.state == 'commit' || steps.publication.outputs.state == 'tag'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_STATE: ${{ steps.publication.outputs.state }}
           RELEASE_VERSION: ${{ needs.check.outputs.release_version }}
         run: |
           TAG="ios-v${RELEASE_VERSION}"
           if [ "$RELEASE_STATE" = "commit" ]; then
-            git tag "$TAG" HEAD
-            git push origin "$TAG"
+            TAG_SHA=$(git rev-parse HEAD)
+            if ! gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$TAG" -f sha="$TAG_SHA" > /dev/null 2>&1; then
+              EXISTING_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.sha')
+              if [ "$EXISTING_SHA" != "$TAG_SHA" ]; then
+                echo "::error::$TAG already points to $EXISTING_SHA instead of $TAG_SHA"
+                exit 1
+              fi
+            fi
           fi
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
 
@@ -573,11 +580,21 @@ jobs:
             const appID = apps.data[0].id;
 
             async function buildExists() {
+              const versions = await asc('/v1/preReleaseVersions', {
+                'filter[app]': appID,
+                'filter[version]': process.env.MARKETING_VERSION,
+                'filter[platform]': 'IOS',
+                'fields[preReleaseVersions]': 'version,platform',
+                limit: '2',
+              });
+              if (versions.data.length === 0) return false;
+              if (versions.data.length !== 1) {
+                throw new Error(`Expected one iOS prerelease version for ${process.env.MARKETING_VERSION}`);
+              }
               const builds = await asc('/v1/builds', {
                 'filter[app]': appID,
                 'filter[version]': process.env.BUILD_NUMBER,
-                'filter[preReleaseVersion.version]': process.env.MARKETING_VERSION,
-                'filter[preReleaseVersion.platform]': 'IOS',
+                'filter[preReleaseVersion]': versions.data[0].id,
                 'fields[builds]': 'version,processingState,uploadedDate',
                 limit: '2',
               });

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -6,10 +6,14 @@ on:
     paths:
       - 'ios/**'
       - 'openapi.yaml'
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Validate tests, archive, and export without publishing or uploading'
+        description: 'Validate archive and export without publishing or uploading'
         type: boolean
         default: false
 
@@ -18,6 +22,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  checks: read
   contents: write
   issues: write
   pull-requests: write
@@ -27,12 +32,19 @@ jobs:
     name: Check for iOS changes
     runs-on: ubuntu-latest
     outputs:
+      has_release: ${{ steps.version.outputs.has_release }}
+      release_version: ${{ steps.version.outputs.release_version }}
       should_release: ${{ steps.diff.outputs.has_changes }}
+      source_sha: ${{ steps.source_sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
+
+      - name: Record release source commit
+        id: source_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Check for iOS-relevant changes since last tag
         id: diff
@@ -52,51 +64,18 @@ jobs:
             fi
           fi
 
-  preflight:
-    name: Test, Archive & Export
-    needs: check
-    if: needs.check.outputs.should_release == 'true'
-    runs-on: macos-26
-    timeout-minutes: 60
-    outputs:
-      release_version: ${{ steps.version.outputs.release_version }}
-      has_release: ${{ steps.version.outputs.has_release }}
-      source_sha: ${{ steps.source_sha.outputs.sha }}
-    steps:
-      # Check out the BRANCH TIP, not github.sha. This workflow shares the
-      # release-<ref> concurrency group with release.yml, so it can start only
-      # after that workflow already pushed a version-bump commit to main. A
-      # checkout pinned to the triggering sha is then one commit behind the remote
-      # and semantic-release refuses to release from a stale branch: "The local
-      # branch main is behind the remote one". github.ref resolves at execution
-      # time, so it includes that bump.
-      # Fixed once in 8a72195, then reverted by 60189c3 and b8f9dd9, which broke
-      # the 2026-08-10 release. Do not put github.sha back.
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      # Pin everything downstream to the exact commit this job built, so publish
-      # cannot silently release a newer one if main advances during the macOS
-      # archive (several minutes).
-      - name: Record the built source commit
-        id: source_sha
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - uses: actions/setup-node@v6
+        if: steps.diff.outputs.has_changes == 'true'
         with:
           node-version: 24
           cache: npm
 
       - name: Install npm dependencies
+        if: steps.diff.outputs.has_changes == 'true'
         run: npm ci
 
-      - name: Install XcodeGen
-        run: brew install xcodegen xcbeautify
-
       - name: Determine release version
+        if: steps.diff.outputs.has_changes == 'true'
         id: version
         working-directory: ios
         env:
@@ -121,122 +100,81 @@ jobs:
             exit 1
           fi
 
-      - name: Stop when no release is due
-        if: steps.version.outputs.has_release != 'true'
-        run: echo "No iOS release is due."
+      # This workflow runs no tests, so the release is gated on the iOS suite having
+      # already passed. Squash and rebase merges give main a new sha, so the check is
+      # looked up on the originating pull request head when the release sha has none.
+      - name: Verify iOS tests passed for this source
+        if: steps.version.outputs.has_release == 'true' && inputs.dry_run != true
+        env:
+          CHECK_NAME: Build & Test (iOS Simulator)
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          conclusion_for() {
+            gh api "repos/$GITHUB_REPOSITORY/commits/$1/check-runs?per_page=100" \
+              | jq -r --arg name "$CHECK_NAME" \
+                '[.check_runs[] | select(.name == $name)] | (.[0].conclusion // "")'
+          }
+
+          TESTED_SHA="$SOURCE_SHA"
+          CONCLUSION=$(conclusion_for "$SOURCE_SHA")
+          PR=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA/pulls" --jq '.[0].number // empty')
+
+          if [ "$CONCLUSION" != "success" ] && [ -n "$PR" ]; then
+            TESTED_SHA=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SOURCE_SHA/pulls" --jq '.[0].head.sha // empty')
+            CONCLUSION=$(conclusion_for "$TESTED_SHA")
+          fi
+
+          if [ "$CONCLUSION" != "success" ]; then
+            echo "::error::No successful '$CHECK_NAME' for $SOURCE_SHA or its pull request head. Run the iOS checks before releasing."
+            exit 1
+          fi
+
+          echo "- Verified \`$CHECK_NAME\` passed for \`$TESTED_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+
+          # A green check on the PR head only covers the tree that was tested. Merging
+          # without rebasing onto other iOS changes releases a combination nothing ran.
+          if [ "$TESTED_SHA" != "$SOURCE_SHA" ] && [ -n "$PR" ]; then
+            git fetch --no-tags --quiet origin "refs/pull/$PR/head"
+            if ! git diff --quiet FETCH_HEAD "$SOURCE_SHA" -- ios openapi.yaml functions migrations; then
+              echo "::warning::iOS paths changed between tested commit $TESTED_SHA and $SOURCE_SHA; this combination was never tested together"
+              echo "- :warning: iOS paths drifted since \`$TESTED_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+  preflight:
+    name: Archive, Export & Publish
+    needs: check
+    if: needs.check.outputs.should_release == 'true' && needs.check.outputs.has_release == 'true'
+    runs-on: macos-26
+    timeout-minutes: 45
+    steps:
+      # Build the exact branch tip used to calculate the release version.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.check.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install XcodeGen
+        run: brew install xcodegen xcbeautify
 
       - name: Apply release version locally
-        if: steps.version.outputs.has_release == 'true'
         working-directory: ios
-        run: scripts/bump-version.sh set "${{ steps.version.outputs.release_version }}" --quiet
-
-      - name: Generate Xcode project
-        if: steps.version.outputs.has_release == 'true'
-        working-directory: ios
-        run: xcodegen generate
+        run: scripts/bump-version.sh set "${{ needs.check.outputs.release_version }}" --quiet
 
       - name: Resolve SPM dependencies
-        if: steps.version.outputs.has_release == 'true'
         working-directory: ios
         run: xcodebuild -resolvePackageDependencies -project WingDex.xcodeproj -scheme Production -onlyUsePackageVersionsFromResolvedFile
 
-      # The preflight tests must never touch the production backend. The old step
-      # ran the Production scheme (Production Debug config, API_BASE_URL=https://wingdex.app).
-      # Because that is a debug build, the app's #if DEBUG launch hooks compile in, so
-      # the UI tests' --auto-sign-in and --auto-demo-data created real anonymous accounts
-      # and wrote demo rows into the live database. Switching to the Dev scheme was
-      # rejected: dev and prod APIs drift, so dev does not validate the released code.
-      # Instead, stand up a throwaway local Worker (mirroring ios.yml) and point the app
-      # at it. Release build and signing validation still happens in the Archive step,
-      # which builds the Production/Release configuration.
-      - name: Write .dev.vars for local Worker
-        if: steps.version.outputs.has_release == 'true'
-        run: |
-          umask 077
-          printf 'BETTER_AUTH_SECRET=%s\nGEOAPIFY_KEY=%s\n' \
-            "$BETTER_AUTH_SECRET" "$GEOAPIFY_KEY" > .dev.vars
-        env:
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          GEOAPIFY_KEY: ${{ secrets.GEOAPIFY_KEY }}
-
-      - name: Build web app
-        if: steps.version.outputs.has_release == 'true'
-        run: npm run build
-
-      - name: Apply local D1 migrations
-        if: steps.version.outputs.has_release == 'true'
-        run: npm run db:migrate
-
-      - name: Start local Worker
-        if: steps.version.outputs.has_release == 'true'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          npm run dev &
-          for i in $(seq 1 30); do
-            curl -sf http://localhost:5000/api/health > /dev/null 2>&1 && break || sleep 1
-          done
-          curl -sf http://localhost:5000/api/health > /dev/null 2>&1 || (echo "Server failed to start within 30s"; exit 1)
-          echo "Server ready on :5000"
-
-      - name: Prepare iOS Simulator
-        if: steps.version.outputs.has_release == 'true'
-        run: |
-          set -euo pipefail
-          RUNTIME_ID=$(xcrun simctl list runtimes -j | jq -r '[.runtimes[] | select(.isAvailable == true and ((.identifier // "") | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))] | last | .identifier // empty')
-          if [ -z "$RUNTIME_ID" ]; then
-            xcodebuild -downloadPlatform iOS
-            RUNTIME_ID=$(xcrun simctl list runtimes -j | jq -r '[.runtimes[] | select(.isAvailable == true and ((.identifier // "") | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))] | last | .identifier // empty')
-          fi
-          if [ -z "$RUNTIME_ID" ]; then
-            echo "No available iOS Simulator runtime after download"
-            exit 1
-          fi
-
-          DEVICE_TYPE_ID=$(xcrun simctl list devicetypes -j | jq -r '
-            [.devicetypes[] | select(.productFamily == "iPhone")]
-            | sort_by(if .name == "iPhone 17 Pro" then 0 else 1 end)
-            | first
-            | .identifier // empty
-          ')
-          if [ -z "$DEVICE_TYPE_ID" ]; then
-            echo "No iPhone Simulator device type is available"
-            exit 1
-          fi
-
-          IOS_SIMULATOR_UDID=$(xcrun simctl create "WingDex CI" "$DEVICE_TYPE_ID" "$RUNTIME_ID")
-          echo "IOS_SIMULATOR_UDID=$IOS_SIMULATOR_UDID" >> "$GITHUB_ENV"
-          xcrun simctl boot "$IOS_SIMULATOR_UDID"
-          xcrun simctl bootstatus "$IOS_SIMULATOR_UDID" -b
-
-      - name: Run iOS tests
-        if: steps.version.outputs.has_release == 'true'
-        timeout-minutes: 30
-        working-directory: ios
-        run: |
-          set -o pipefail
-          mkdir -p build/logs
-          xcodebuild \
-            -project WingDex.xcodeproj \
-            -scheme Localhost \
-            -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_UDID" \
-            -resultBundlePath build/TestResults.xcresult \
-            test \
-            CODE_SIGNING_ALLOWED=NO \
-            API_BASE_URL=http://localhost:5000 \
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) CI' \
-            -onlyUsePackageVersionsFromResolvedFile \
-            2>&1 | tee build/logs/test.log | xcbeautify
-
       - name: Write App Store Connect API key
-        if: steps.version.outputs.has_release == 'true'
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
           echo "${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
 
       - name: Archive for App Store
-        if: steps.version.outputs.has_release == 'true'
         working-directory: ios
         run: |
           set -o pipefail
@@ -254,7 +192,6 @@ jobs:
             2>&1 | tee build/logs/archive.log | xcbeautify
 
       - name: Inspect signed archive
-        if: steps.version.outputs.has_release == 'true'
         working-directory: ios
         env:
           REQUIRE_SIGNED: '1'
@@ -262,7 +199,6 @@ jobs:
         run: scripts/inspect-archive.sh build/WingDex.xcarchive build/archive-inspection
 
       - name: Export IPA
-        if: steps.version.outputs.has_release == 'true'
         working-directory: ios
         run: |
           set -o pipefail
@@ -278,20 +214,17 @@ jobs:
             2>&1 | tee build/logs/export.log | xcbeautify
 
       - name: Upload iOS diagnostics
-        if: always() && steps.version.outputs.has_release == 'true'
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: iOS-release-diagnostics
-          path: |
-            ios/build/TestResults.xcresult
-            ios/build/logs/
+          path: ios/build/logs/
           retention-days: 7
 
       - name: Upload validated IPA artifact
-        if: steps.version.outputs.has_release == 'true'
         uses: actions/upload-artifact@v6
         with:
-          name: WingDex-${{ steps.version.outputs.release_version }}
+          name: WingDex-${{ needs.check.outputs.release_version }}
           path: |
             ios/build/export/WingDex.ipa
             ios/build/archive-inspection/
@@ -303,7 +236,7 @@ jobs:
       # development certificate every run. Left alone they pile up until the account cap
       # is hit. Their private keys die with the runner, so revoking them is always safe.
       - name: Revoke CI-created signing certificates
-        if: always() && steps.version.outputs.has_release == 'true'
+        if: always()
         continue-on-error: true
         uses: actions/github-script@v9
         env:
@@ -368,69 +301,77 @@ jobs:
               core.setFailed(`${failed} of ${stale.length} certificate(s) could not be revoked`);
             }
 
-      - name: Clean up API key
-        if: always()
-        run: rm -rf ~/.appstoreconnect
-
       - name: Validation summary
-        if: steps.version.outputs.has_release == 'true'
         run: |
-          echo "### Validated iOS v${{ steps.version.outputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Tests, signed archive inspection, dSYM matching, and App Store export succeeded before publication." >> "$GITHUB_STEP_SUMMARY"
-
-  publish:
-    name: Publish & Upload to TestFlight
-    needs: [check, preflight]
-    if: needs.check.outputs.should_release == 'true' && needs.preflight.outputs.has_release == 'true' && inputs.dry_run != true
-    runs-on: macos-26
-    timeout-minutes: 45
-    steps:
-      # Check out the exact commit preflight built and versioned, NOT the branch tip.
-      # Preflight already resolved the tip to pick up any version bump release.yml
-      # pushed while this run was queued. Re-resolving here would open a second
-      # window: another merge can advance main during the macOS archive, and
-      # semantic-release would then tag commits that are not in the IPA this job
-      # uploads. Pinning keeps the released tag, the version, and the artifact in
-      # agreement.
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.preflight.outputs.source_sha }}
-          fetch-depth: 0
-          persist-credentials: false
+          echo "### Validated iOS v${{ needs.check.outputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "Signed archive inspection, dSYM matching, and App Store export succeeded before publication." >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/setup-node@v6
+        if: inputs.dry_run != true
         with:
           node-version: 24
           cache: npm
 
       - name: Install npm dependencies
+        if: inputs.dry_run != true
         run: npm ci
 
-      - name: Install XcodeGen
-        run: brew install xcodegen
+      - name: Verify release source is still current
+        if: inputs.dry_run != true
+        env:
+          SOURCE_SHA: ${{ needs.check.outputs.source_sha }}
+        run: |
+          git fetch origin refs/heads/main:refs/remotes/origin/main
+          REMOTE_SHA=$(git rev-parse refs/remotes/origin/main)
+          if [ "$REMOTE_SHA" != "$SOURCE_SHA" ]; then
+            echo "::error::main advanced from $SOURCE_SHA to $REMOTE_SHA while the archive was built"
+            exit 1
+          fi
+          git checkout -B main "$SOURCE_SHA"
+          git branch --set-upstream-to=origin/main main
 
       - name: Publish semantic release
+        if: inputs.dry_run != true
         working-directory: ios
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
-      - name: Download validated IPA artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: WingDex-${{ needs.preflight.outputs.release_version }}
-          path: build
-
-      - name: Write App Store Connect API key
+      - name: Verify published release
+        if: inputs.dry_run != true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.check.outputs.release_version }}
+          SOURCE_SHA: ${{ needs.check.outputs.source_sha }}
         run: |
-          mkdir -p ~/.appstoreconnect/private_keys
-          echo "${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}.p8
+          TAG="ios-v${RELEASE_VERSION}"
+          git fetch origin refs/heads/main:refs/remotes/origin/main --tags
+          TAG_SHA=$(git rev-parse "${TAG}^{commit}")
+          TAG_PARENT_SHA=$(git rev-parse "${TAG_SHA}^")
+          REMOTE_SHA=$(git rev-parse refs/remotes/origin/main)
+          if [ "$TAG_PARENT_SHA" != "$SOURCE_SHA" ] || [ "$TAG_SHA" != "$REMOTE_SHA" ]; then
+            echo "::error::$TAG does not identify a release commit directly after the archived source"
+            exit 1
+          fi
+          gh release view "$TAG" > /dev/null
+
+      - name: Mark pre-1.0 releases as prerelease
+        if: inputs.dry_run != true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.check.outputs.release_version }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          if [ "$MAJOR" = "0" ]; then
+            gh release edit "ios-v${VERSION}" --prerelease
+          fi
 
       - name: Upload to TestFlight
+        if: inputs.dry_run != true
         run: |
           xcrun altool --upload-app \
             --type ios \
-            --file build/export/WingDex.ipa \
+            --file ios/build/export/WingDex.ipa \
             --apiKey "${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}" \
             --apiIssuer "${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}"
 
@@ -438,17 +379,8 @@ jobs:
         if: always()
         run: rm -rf ~/.appstoreconnect
 
-      - name: Mark pre-1.0 releases as prerelease
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ needs.preflight.outputs.release_version }}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          if [ "$MAJOR" = "0" ]; then
-            gh release edit "ios-v${VERSION}" --prerelease
-          fi
-
       - name: Summary
+        if: inputs.dry_run != true
         run: |
-          echo "### iOS Release v${{ needs.preflight.outputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### iOS Release v${{ needs.check.outputs.release_version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "Published and uploaded to TestFlight." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -10,6 +10,7 @@ on:
       - 'migrations/**'
       - '.github/workflows/ios.yml'
       - '.github/workflows/ios-release.yml'
+      - '.github/workflows/release.yml'
   push:
     branches: [dev]
     paths:
@@ -19,6 +20,7 @@ on:
       - 'migrations/**'
       - '.github/workflows/ios.yml'
       - '.github/workflows/ios-release.yml'
+      - '.github/workflows/release.yml'
 
 concurrency:
   group: ios-${{ github.ref }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -87,12 +87,8 @@ jobs:
           xcrun simctl boot "$IOS_SIMULATOR_UDID"
 
       - name: Install XcodeGen
-        env:
-          HOMEBREW_NO_AUTO_UPDATE: '1'
         run: |
-          command -v xcodegen > /dev/null || brew install xcodegen
-          command -v xcbeautify > /dev/null || brew install xcbeautify
-          xcodegen --version
+          ios/scripts/install-xcodegen.sh
           xcbeautify --version
 
       - name: Generate Xcode project

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,90 +8,64 @@ on:
       - 'openapi.yaml'
       - 'functions/**'
       - 'migrations/**'
+      - '.github/workflows/ios.yml'
+      - '.github/workflows/ios-release.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ios/**'
+      - 'openapi.yaml'
+      - 'functions/**'
+      - 'migrations/**'
+      - '.github/workflows/ios.yml'
+      - '.github/workflows/ios-release.yml'
 
 concurrency:
   group: ios-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  deployments: read
 
 jobs:
   build-and-test:
     name: Build & Test (iOS Simulator)
     runs-on: macos-26
     timeout-minutes: 45
-    env:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v6
 
-      # -- Node + Wrangler server (for auth integration tests) --
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
-      - name: Cache node_modules
-        id: node-modules-cache
-        uses: actions/cache@v5
-        with:
-          path: node_modules
-          key: node-modules-macos-${{ hashFiles('package-lock.json') }}
-
-      - name: Install npm dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: npm ci
-
-      - name: Build web app
-        run: npm run build
-
-      - name: Write .dev.vars for local dev server
-        run: |
-          umask 077
-          printf 'BETTER_AUTH_SECRET=%s\nGEOAPIFY_KEY=%s\n' \
-            "$BETTER_AUTH_SECRET" "$GEOAPIFY_KEY" > .dev.vars
-        env:
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          GEOAPIFY_KEY: ${{ secrets.GEOAPIFY_KEY }}
-
-      - name: Apply local D1 migrations
-        run: npm run db:migrate
-
-      - name: Start dev server
-        run: |
-          npm run dev &
-          for i in $(seq 1 30); do
-            curl -sf http://localhost:5000/api/health > /dev/null 2>&1 && break || sleep 1
-          done
-          curl -sf http://localhost:5000/api/health > /dev/null 2>&1 || (echo "Server failed to start within 30s"; exit 1)
-          echo "Server ready on :5000"
-
-      # -- Xcode build + test --
-
-      - name: Install XcodeGen
-        run: brew install xcodegen
-
-      - name: Generate GitInfo.swift
-        working-directory: ios
-        run: scripts/gen-git-info.sh
-
-      - name: Generate Xcode project
-        working-directory: ios
-        run: xcodegen generate
-
-      - name: Resolve SPM dependencies
-        working-directory: ios
-        run: xcodebuild -resolvePackageDependencies -project WingDex.xcodeproj -scheme Dev
-
-      - name: Prepare iOS Simulator
+      - name: Start iOS Simulator
         run: |
           set -euo pipefail
-          RUNTIME_ID=$(xcrun simctl list runtimes -j | jq -r '[.runtimes[] | select(.isAvailable == true and ((.identifier // "") | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))] | last | .identifier // empty')
+          echo "Available simulators before CI device creation:"
+          xcrun simctl list devices available
+
+          SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          RUNTIME_ID=$(xcrun simctl list runtimes -j | jq -r --arg version "$SDK_VERSION" '
+            [.runtimes[] | select(
+              .isAvailable == true
+              and .version == $version
+              and ((.identifier // "") | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
+            )]
+            | first
+            | .identifier // empty
+          ')
           if [ -z "$RUNTIME_ID" ]; then
             xcodebuild -downloadPlatform iOS
-            RUNTIME_ID=$(xcrun simctl list runtimes -j | jq -r '[.runtimes[] | select(.isAvailable == true and ((.identifier // "") | startswith("com.apple.CoreSimulator.SimRuntime.iOS-")))] | last | .identifier // empty')
+            RUNTIME_ID=$(xcrun simctl list runtimes -j | jq -r --arg version "$SDK_VERSION" '
+              [.runtimes[] | select(
+                .isAvailable == true
+                and .version == $version
+                and ((.identifier // "") | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
+              )]
+              | first
+              | .identifier // empty
+            ')
           fi
           if [ -z "$RUNTIME_ID" ]; then
-            echo "No available iOS Simulator runtime after download"
+            echo "No iOS $SDK_VERSION Simulator runtime is available"
             exit 1
           fi
 
@@ -109,19 +83,120 @@ jobs:
           IOS_SIMULATOR_UDID=$(xcrun simctl create "WingDex CI" "$DEVICE_TYPE_ID" "$RUNTIME_ID")
           echo "IOS_SIMULATOR_UDID=$IOS_SIMULATOR_UDID" >> "$GITHUB_ENV"
           xcrun simctl boot "$IOS_SIMULATOR_UDID"
-          xcrun simctl bootstatus "$IOS_SIMULATOR_UDID" -b
+
+      - name: Install XcodeGen
+        run: brew install xcodegen xcbeautify
+
+      - name: Generate GitInfo.swift
+        working-directory: ios
+        run: scripts/gen-git-info.sh
+
+      - name: Generate Xcode project
+        working-directory: ios
+        run: xcodegen generate
+
+      - name: Resolve SPM dependencies
+        working-directory: ios
+        run: xcodebuild -resolvePackageDependencies -project WingDex.xcodeproj -scheme Dev
 
       - name: Build for Simulator
         working-directory: ios
         run: |
           set -o pipefail
+          mkdir -p build/logs
           xcodebuild build-for-testing \
             -project WingDex.xcodeproj \
             -scheme Dev \
             -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_UDID" \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO \
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) CI'
+            2>&1 | tee build/logs/build.log | xcbeautify
+
+      - name: Select API backend
+        env:
+          DEV_URL: https://dev.wingdex.app
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.head_ref }}
+          PREVIEW_ENVIRONMENT: preview (#${{ github.event.pull_request.number }})
+          PREVIEW_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          probe_backend() {
+            local response
+            response=$(curl -fsS --max-time 15 "$1/api/health" 2>/dev/null) || return 1
+            jq -e '.status == "ok" and .db == "ok"' <<< "$response" > /dev/null
+          }
+
+          wait_for_backend() {
+            local url="$1"
+            local attempts="$2"
+            for ((attempt = 1; attempt <= attempts; attempt++)); do
+              if probe_backend "$url"; then
+                return 0
+              fi
+              if ((attempt < attempts)); then
+                sleep 5
+              fi
+            done
+            return 1
+          }
+
+          wait_for_preview() {
+            local attempts="$1"
+            local deployment_id
+            local preview_url
+            for ((attempt = 1; attempt <= attempts; attempt++)); do
+              if ! deployment_id=$(gh api --method GET "repos/$GITHUB_REPOSITORY/deployments" \
+                -f sha="$PREVIEW_SHA" \
+                -f environment="$PREVIEW_ENVIRONMENT" \
+                -f per_page=1 \
+                --jq '.[0].id // empty' 2>/dev/null); then
+                return 1
+              fi
+              if [ -n "$deployment_id" ]; then
+                if ! preview_url=$(gh api "repos/$GITHUB_REPOSITORY/deployments/$deployment_id/statuses" \
+                  --jq 'if .[0].state == "success" then (.[0].environment_url // "") else "" end' 2>/dev/null); then
+                  return 1
+                fi
+                if [ -n "$preview_url" ] && probe_backend "$preview_url"; then
+                  API_BASE_URL="$preview_url"
+                  return 0
+                fi
+              fi
+              if ((attempt < attempts)); then
+                sleep 5
+              fi
+            done
+            return 1
+          }
+
+          API_BASE_URL="$DEV_URL"
+          BACKEND_SOURCE="dev"
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REF" != "dev" ] && [ "$HEAD_REF" != "main" ]; then
+            if wait_for_preview 12; then
+              BACKEND_SOURCE="PR preview"
+            else
+              BACKEND_SOURCE="dev fallback"
+              echo "::warning::PR preview did not become healthy; falling back to dev"
+            fi
+          fi
+
+          if ! wait_for_backend "$API_BASE_URL" 6; then
+            echo "::error::Selected iOS test backend is not healthy: $API_BASE_URL"
+            exit 1
+          fi
+
+          echo "API_BASE_URL=$API_BASE_URL" >> "$GITHUB_ENV"
+          {
+            echo "### iOS test backend"
+            echo "- URL: \`$API_BASE_URL\`"
+            echo "- Selection: $BACKEND_SOURCE"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Wait for iOS Simulator
+        run: xcrun simctl bootstatus "$IOS_SIMULATOR_UDID" -b
 
       - name: Run tests
         working-directory: ios
@@ -130,14 +205,15 @@ jobs:
           # xcodebuild does not create missing parents for -resultBundlePath, and
           # ios/build does not exist in a clean checkout.
           mkdir -p build
-          xcodebuild test-without-building \
+          TEST_RUNNER_API_BASE_URL="$API_BASE_URL" xcodebuild test-without-building \
             -project WingDex.xcodeproj \
             -scheme Dev \
             -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_UDID" \
             -resultBundlePath build/TestResults.xcresult \
             -only-testing:WingDexTests \
             -only-testing:WingDexUITests \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | tee build/logs/test.log | xcbeautify
 
       - name: Upload iOS test diagnostics
         if: always()

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -155,12 +155,12 @@ jobs:
                 -f environment="$PREVIEW_ENVIRONMENT" \
                 -f per_page=1 \
                 --jq '.[0].id // empty' 2>/dev/null); then
-                return 1
+                deployment_id=""
               fi
               if [ -n "$deployment_id" ]; then
                 if ! preview_url=$(gh api "repos/$GITHUB_REPOSITORY/deployments/$deployment_id/statuses" \
                   --jq 'if .[0].state == "success" then (.[0].environment_url // "") else "" end' 2>/dev/null); then
-                  return 1
+                  preview_url=""
                 fi
                 if [ -n "$preview_url" ] && probe_backend "$preview_url"; then
                   API_BASE_URL="$preview_url"
@@ -177,18 +177,24 @@ jobs:
           API_BASE_URL="$DEV_URL"
           BACKEND_SOURCE="dev"
           if [ "$EVENT_NAME" = "pull_request" ] && [ "$HEAD_REF" != "dev" ] && [ "$HEAD_REF" != "main" ]; then
-            if wait_for_preview 12; then
-              BACKEND_SOURCE="PR preview"
-            else
-              BACKEND_SOURCE="dev fallback"
-              echo "::warning::PR preview did not become healthy; falling back to dev"
+            echo "Waiting for $PREVIEW_ENVIRONMENT at commit $PREVIEW_SHA"
+            if ! wait_for_preview 60; then
+              echo "::error::The exact PR preview did not become healthy: $PREVIEW_ENVIRONMENT at $PREVIEW_SHA"
+              exit 1
             fi
+            BACKEND_SOURCE="PR preview"
+          else
+            echo "This event does not create a PR preview; using the dev backend"
           fi
 
           if ! wait_for_backend "$API_BASE_URL" 6; then
             echo "::error::Selected iOS test backend is not healthy: $API_BASE_URL"
             exit 1
           fi
+
+          echo "Selected iOS test backend: $BACKEND_SOURCE"
+          echo "Backend URL: $API_BASE_URL"
+          echo "Health check: ok"
 
           echo "API_BASE_URL=$API_BASE_URL" >> "$GITHUB_ENV"
           {

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -87,19 +87,17 @@ jobs:
           xcrun simctl boot "$IOS_SIMULATOR_UDID"
 
       - name: Install XcodeGen
-        run: brew install xcodegen xcbeautify
-
-      - name: Generate GitInfo.swift
-        working-directory: ios
-        run: scripts/gen-git-info.sh
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: '1'
+        run: |
+          command -v xcodegen > /dev/null || brew install xcodegen
+          command -v xcbeautify > /dev/null || brew install xcbeautify
+          xcodegen --version
+          xcbeautify --version
 
       - name: Generate Xcode project
         working-directory: ios
         run: xcodegen generate
-
-      - name: Resolve SPM dependencies
-        working-directory: ios
-        run: xcodebuild -resolvePackageDependencies -project WingDex.xcodeproj -scheme Dev
 
       - name: Build for Simulator
         working-directory: ios
@@ -110,6 +108,7 @@ jobs:
             -project WingDex.xcodeproj \
             -scheme Dev \
             -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_UDID" \
+            -onlyUsePackageVersionsFromResolvedFile \
             -skipPackagePluginValidation \
             CODE_SIGNING_ALLOWED=NO \
             2>&1 | tee build/logs/build.log | xcbeautify
@@ -217,6 +216,7 @@ jobs:
             -project WingDex.xcodeproj \
             -scheme Dev \
             -destination "platform=iOS Simulator,id=$IOS_SIMULATOR_UDID" \
+            -onlyUsePackageVersionsFromResolvedFile \
             -resultBundlePath build/TestResults.xcresult \
             -only-testing:WingDexTests \
             -only-testing:WingDexUITests \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,28 +85,52 @@ jobs:
             echo "release_state=$STATE"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Reject superseded source
+        if: steps.source.outputs.is_current != 'true'
+        run: |
+          echo "::error::This release source was superseded; the newest queued run will carry its changes forward"
+          exit 1
+
       - name: Check for deployable changes
         id: changes
         env:
-          BEFORE_SHA: ${{ github.event.before || '' }}
-          CREATED: ${{ github.event.created || false }}
           EVENT_NAME: ${{ github.event_name }}
-          SOURCE_IS_CURRENT: ${{ steps.source.outputs.is_current }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "$SOURCE_IS_CURRENT" != "true" ]; then
-            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
-            || [ "$CREATED" = "true" ] \
-            || [ -z "$BEFORE_SHA" ] \
-            || [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          CHANGED=$(git diff --name-only "$BEFORE_SHA"..HEAD | awk '
+          BASE_SHA=$(gh api --method GET \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/release.yml/runs" \
+            -f branch="$GITHUB_REF_NAME" \
+            -f status=success \
+            -f per_page=1 \
+            --jq '.workflow_runs[0].head_sha // empty')
+          if [ -z "$BASE_SHA" ] || ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+            echo "No successful Release ancestor found; deploying the full current source"
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FIRST_AFTER_BASE=$(git rev-list --ancestry-path --reverse "$BASE_SHA..HEAD" | head -1)
+          if [ -n "$FIRST_AFTER_BASE" ]; then
+            read -r -a PARENTS <<< "$(git show -s --format=%P "$FIRST_AFTER_BASE")"
+            AUTHOR_EMAIL=$(git show -s --format=%ae "$FIRST_AFTER_BASE")
+            SUBJECT=$(git show -s --format=%s "$FIRST_AFTER_BASE")
+            UNEXPECTED=$(git diff --name-only "$BASE_SHA" "$FIRST_AFTER_BASE" \
+              | grep -Ev '^(CHANGELOG\.md|package\.json|package-lock\.json)$' || true)
+            if [ "${#PARENTS[@]}" -eq 1 ] \
+              && [ "${PARENTS[0]}" = "$BASE_SHA" ] \
+              && [ "$AUTHOR_EMAIL" = "semantic-release-bot@martynus.net" ] \
+              && [[ "$SUBJECT" == chore\(Release\):* ]] \
+              && [ -z "$UNEXPECTED" ]; then
+              BASE_SHA="$FIRST_AFTER_BASE"
+            fi
+          fi
+
+          CHANGED=$(git diff --name-only "$BASE_SHA"..HEAD | awk '
             !(/\.md$/ || /^docs\// || /^\.vscode\// || /^ios\//) { print }
           ')
           if [ -n "$CHANGED" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,14 +138,21 @@ jobs:
       - name: Repair partial publication
         if: steps.changes.outputs.should_deploy == 'true' && github.ref == 'refs/heads/main' && (steps.source.outputs.release_state == 'commit' || steps.source.outputs.release_state == 'tag')
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_STATE: ${{ steps.source.outputs.release_state }}
         run: |
           VERSION=$(jq -r .version package.json)
           TAG="v$VERSION"
           if [ "$RELEASE_STATE" = "commit" ]; then
-            git tag "$TAG" HEAD
-            git push origin "$TAG"
+            TAG_SHA=$(git rev-parse HEAD)
+            if ! gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$TAG" -f sha="$TAG_SHA" > /dev/null 2>&1; then
+              EXISTING_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq '.object.sha')
+              if [ "$EXISTING_SHA" != "$TAG_SHA" ]; then
+                echo "::error::$TAG already points to $EXISTING_SHA instead of $TAG_SHA"
+                exit 1
+              fi
+            fi
           fi
           gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,6 @@ name: Release
 on:
   push:
     branches: [main, dev]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.vscode/**'
-      - 'ios/**'
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write
@@ -30,32 +26,135 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Resolve release source
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TRIGGER_SHA=$(git rev-parse HEAD)
+          git fetch origin "refs/heads/$GITHUB_REF_NAME:refs/remotes/origin/$GITHUB_REF_NAME" --tags
+          REMOTE_SHA=$(git rev-parse "refs/remotes/origin/$GITHUB_REF_NAME")
+          STATE=source
+          IS_CURRENT=true
+
+          if [ "$REMOTE_SHA" != "$TRIGGER_SHA" ]; then
+            STATE=stale
+            IS_CURRENT=false
+            if [ "$GITHUB_REF_NAME" = "main" ]; then
+              read -r -a PARENTS <<< "$(git show -s --format=%P "$REMOTE_SHA")"
+              VERSION=$(git show "$REMOTE_SHA:package.json" | jq -r .version)
+              AUTHOR_EMAIL=$(git show -s --format=%ae "$REMOTE_SHA")
+              SUBJECT=$(git show -s --format=%s "$REMOTE_SHA")
+              UNEXPECTED=$(git diff --name-only "$TRIGGER_SHA" "$REMOTE_SHA" \
+                | grep -Ev '^(CHANGELOG\.md|package\.json|package-lock\.json)$' || true)
+              if [ "${#PARENTS[@]}" -eq 1 ] \
+                && [ "${PARENTS[0]}" = "$TRIGGER_SHA" ] \
+                && [ "$AUTHOR_EMAIL" = "semantic-release-bot@martynus.net" ] \
+                && [ "$SUBJECT" = "chore(Release): $VERSION" ] \
+                && [ -z "$UNEXPECTED" ]; then
+                TAG="v$VERSION"
+                IS_CURRENT=true
+                if git rev-parse "refs/tags/$TAG" > /dev/null 2>&1; then
+                  if [ "$(git rev-parse "${TAG}^{commit}")" != "$REMOTE_SHA" ]; then
+                    echo "::error::$TAG does not point to release commit $REMOTE_SHA"
+                    exit 1
+                  fi
+                  if gh release view "$TAG" > /dev/null 2>&1; then
+                    STATE=complete
+                  else
+                    STATE=tag
+                  fi
+                else
+                  STATE=commit
+                fi
+              fi
+            fi
+          fi
+
+          if [ "$IS_CURRENT" = "true" ]; then
+            git checkout -B "$GITHUB_REF_NAME" "$REMOTE_SHA"
+            git branch --set-upstream-to="origin/$GITHUB_REF_NAME" "$GITHUB_REF_NAME"
+          fi
+          {
+            echo "is_current=$IS_CURRENT"
+            echo "release_state=$STATE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check for deployable changes
+        id: changes
+        env:
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          CREATED: ${{ github.event.created || false }}
+          EVENT_NAME: ${{ github.event_name }}
+          SOURCE_IS_CURRENT: ${{ steps.source.outputs.is_current }}
+        run: |
+          if [ "$SOURCE_IS_CURRENT" != "true" ]; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
+            || [ "$CREATED" = "true" ] \
+            || [ -z "$BEFORE_SHA" ] \
+            || [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only "$BEFORE_SHA"..HEAD | awk '
+            !(/\.md$/ || /^docs\// || /^\.vscode\// || /^ios\//) { print }
+          ')
+          if [ -n "$CHANGED" ]; then
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/setup-node@v6
+        if: steps.changes.outputs.should_deploy == 'true'
         with:
           node-version: 24
           cache: npm
 
       - name: Install dependencies
+        if: steps.changes.outputs.should_deploy == 'true'
         run: npm ci
 
       - name: Pre-release typecheck
-        if: github.ref == 'refs/heads/main'
+        if: steps.changes.outputs.should_deploy == 'true' && github.ref == 'refs/heads/main'
         run: npm run typecheck
 
       - name: Run semantic-release
-        if: github.ref == 'refs/heads/main'
+        if: steps.changes.outputs.should_deploy == 'true' && github.ref == 'refs/heads/main' && steps.source.outputs.release_state == 'source'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
+      - name: Repair partial publication
+        if: steps.changes.outputs.should_deploy == 'true' && github.ref == 'refs/heads/main' && (steps.source.outputs.release_state == 'commit' || steps.source.outputs.release_state == 'tag')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_STATE: ${{ steps.source.outputs.release_state }}
+        run: |
+          VERSION=$(jq -r .version package.json)
+          TAG="v$VERSION"
+          if [ "$RELEASE_STATE" = "commit" ]; then
+            git tag "$TAG" HEAD
+            git push origin "$TAG"
+          fi
+          gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
+
       - name: Build deploy artifact
+        if: steps.changes.outputs.should_deploy == 'true'
         run: npm run build
 
       - name: Apply D1 migrations
+        if: steps.changes.outputs.should_deploy == 'true'
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
             npx wrangler d1 migrations apply wingdex-db --remote
@@ -67,6 +166,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy to Cloudflare Workers
+        if: steps.changes.outputs.should_deploy == 'true'
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -74,7 +174,7 @@ jobs:
           command: deploy ${{ github.ref != 'refs/heads/main' && '--env preview' || '' }}
 
       - name: Purge production edge cache
-        if: github.ref == 'refs/heads/main'
+        if: steps.changes.outputs.should_deploy == 'true' && github.ref == 'refs/heads/main'
         run: |
           if [ -z "${CLOUDFLARE_ZONE_ID:-}" ]; then
             echo "Missing CLOUDFLARE_ZONE_ID GitHub secret"
@@ -91,6 +191,7 @@ jobs:
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
 
       - name: Verify deployed version
+        if: steps.changes.outputs.should_deploy == 'true'
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
@@ -145,3 +246,9 @@ jobs:
               echo "Warning: could not verify ${DOMAIN} after ${MAX_ATTEMPTS} attempts; continuing for non-main branch"
             fi
           done
+
+      - name: Continue iOS release
+        if: steps.source.outputs.is_current == 'true' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run ios-release.yml --ref main -f source_sha="$(git rev-parse HEAD)"

--- a/ios/WingDex/App/WingDexApp.swift
+++ b/ios/WingDex/App/WingDexApp.swift
@@ -141,6 +141,9 @@ struct MainTabView: View {
     @State private var addPhotosVM = AddPhotosViewModel()
     @State private var showingWizard = false
     @State private var initialDataLoaded = false
+    #if DEBUG
+    @State private var uiTestDataSetupIdentifier = "ui-test.dataSetupPending"
+    #endif
 
     var body: some View {
         @Bindable var navigation = navigation
@@ -178,6 +181,9 @@ struct MainTabView: View {
                 Label("Add", systemImage: "camera.fill")
             }
         }
+        #if DEBUG
+        .accessibilityIdentifier(uiTestDataSetupIdentifier)
+        #endif
         .onChange(of: addPhotosVM.currentStep) {
             if addPhotosVM.currentStep != .selectPhotos {
                 showingWizard = true
@@ -211,11 +217,16 @@ struct MainTabView: View {
             // read the demo dex use the clear flag instead, because importing the CSV
             // delays everything that follows in this task.
             let arguments = ProcessInfo.processInfo.arguments
-            if arguments.contains("--ui-test-clear-data") {
-                try? await store.clearAll()
-            } else if arguments.contains("--ui-test-reset-data")
-                || (arguments.contains("--auto-demo-data") && store.dex.isEmpty) {
-                try? await store.loadDemoData()
+            do {
+                if arguments.contains("--ui-test-clear-data") {
+                    try await store.clearAll()
+                } else if arguments.contains("--ui-test-reset-data")
+                    || (arguments.contains("--auto-demo-data") && store.dex.isEmpty) {
+                    try await store.loadDemoData()
+                }
+                uiTestDataSetupIdentifier = "ui-test.dataSetupComplete"
+            } catch {
+                uiTestDataSetupIdentifier = "ui-test.dataSetupFailed"
             }
             #endif
             await completeInitialLoadIfReady()

--- a/ios/WingDex/Services/AccountDataCache.swift
+++ b/ios/WingDex/Services/AccountDataCache.swift
@@ -17,6 +17,7 @@ protocol AccountDataCaching: AnyObject {
 @MainActor
 final class AccountDataCache: AccountDataCaching {
     static let purgeDenylistKey = "account-data-cache-purge-denylist"
+    private static let sqliteHeader = Data("SQLite format 3\0".utf8)
 
     private let container: ModelContainer
     private let storeDirectory: URL?
@@ -42,6 +43,7 @@ final class AccountDataCache: AccountDataCaching {
 
         let url = try storeURL ?? Self.defaultStoreURL()
         storeDirectory = url.deletingLastPathComponent()
+        try Self.removeStoreDirectoryIfClearlyInvalid(at: url)
         let configuration = ModelConfiguration(
             "WingDexCache",
             schema: schema,
@@ -199,6 +201,29 @@ final class AccountDataCache: AccountDataCaching {
         if fileManager.fileExists(atPath: directory.path) {
             try fileManager.removeItem(at: directory)
         }
+    }
+
+    private static func removeStoreDirectoryIfClearlyInvalid(at storeURL: URL) throws {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: storeURL.path, isDirectory: &isDirectory) else { return }
+        if isDirectory.boolValue {
+            try removeStoreDirectory(at: storeURL.deletingLastPathComponent())
+            try prepareStoreDirectory(storeURL.deletingLastPathComponent())
+            return
+        }
+        guard
+              let handle = try? FileHandle(forReadingFrom: storeURL)
+        else { return }
+        defer { try? handle.close() }
+        let header: Data
+        do {
+            header = try handle.read(upToCount: sqliteHeader.count) ?? Data()
+        } catch {
+            return
+        }
+        guard header != sqliteHeader else { return }
+        try removeStoreDirectory(at: storeURL.deletingLastPathComponent())
+        try prepareStoreDirectory(storeURL.deletingLastPathComponent())
     }
 }
 

--- a/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
@@ -114,6 +114,8 @@ struct OutingReviewView: View {
                 }
             } header: {
                 Text("Location")
+                    .font(.headline)
+                    .foregroundStyle(Color.foregroundText)
             } footer: {
                 locationFooter
             }
@@ -125,6 +127,8 @@ struct OutingReviewView: View {
                 Text("Photos (\(cluster?.photos.count ?? 0))")
                     .font(.headline)
                     .foregroundStyle(Color.foregroundText)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("outing.photosHeader")
             }
         }
         .formStyle(.grouped)

--- a/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
+++ b/ios/WingDex/Views/AddPhotosFlow/OutingReviewView.swift
@@ -204,7 +204,7 @@ struct OutingReviewView: View {
                         Text("GPS detected")
                         if let lat = cluster?.centerLat, let lon = cluster?.centerLon {
                             Text("(\(lat, specifier: "%.4f"), \(lon, specifier: "%.4f"))")
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(Color.foregroundText)
                         }
                     }
                 } icon: {

--- a/ios/WingDex/Views/HomeView.swift
+++ b/ios/WingDex/Views/HomeView.swift
@@ -121,6 +121,7 @@ struct HomeView: View {
                 Text("Got bird pics?")
                     .font(.system(.largeTitle, design: .serif, weight: .semibold))
                     .foregroundStyle(Color.foregroundText)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Text("Upload your photos, ID the birds, and build your WingDex.")
                     .font(.body)
@@ -135,6 +136,7 @@ struct HomeView: View {
                 Label {
                     Text("Upload & Identify")
                         .font(.body.weight(.medium))
+                        .fixedSize(horizontal: false, vertical: true)
                 } icon: {
                     Image(systemName: "camera.fill")
                         .font(.body)

--- a/ios/WingDex/Views/OutingsView.swift
+++ b/ios/WingDex/Views/OutingsView.swift
@@ -168,15 +168,20 @@ struct OutingsView: View {
                     Image(systemName: "binoculars.fill")
                         .font(.system(size: 32))
                         .foregroundStyle(Color.accentColor)
+                        .accessibilityHidden(true)
                 }
                 VStack(spacing: 8) {
                     Text("No Outings Yet")
-                        .font(.system(size: 22, weight: .semibold, design: .serif))
+                        .font(.title2)
+                        .fontDesign(.serif)
+                        .fontWeight(.semibold)
                         .foregroundStyle(Color.foregroundText)
+                        .fixedSize(horizontal: false, vertical: true)
                     Text("Upload photos to create your first outing.")
-                        .font(.system(size: 15))
+                        .font(.body)
                         .foregroundStyle(Color.mutedText)
                         .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer()
             }

--- a/ios/WingDex/Views/SettingsView.swift
+++ b/ios/WingDex/Views/SettingsView.swift
@@ -75,6 +75,14 @@ struct SettingsView: View {
 
     private var profile: ProfileEditor { editor! }
 
+    private var showsAvatarOptions: Bool {
+        #if DEBUG
+        !ProcessInfo.processInfo.arguments.contains("--ui-test-hide-avatar-options")
+        #else
+        true
+        #endif
+    }
+
     var body: some View {
         NavigationStack {
             if editor != nil {
@@ -196,6 +204,7 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .headerProminence(.increased)
         .onChange(of: profile.name, initial: true) { _, name in
             guard !isNameFieldFocused else { return }
             editedName = name
@@ -221,7 +230,7 @@ struct SettingsView: View {
 
     @ViewBuilder
     private var avatarSection: some View {
-        if !profile.name.isEmpty {
+        if !profile.name.isEmpty && showsAvatarOptions {
             Section("Avatar") {
                 ScrollView(.horizontal) {
                     HStack(spacing: 2) {
@@ -254,6 +263,7 @@ struct SettingsView: View {
                 .scrollIndicators(.hidden)
                 .animation(.none, value: profile.image)
             }
+            .headerProminence(.increased)
         }
     }
 
@@ -289,6 +299,7 @@ struct SettingsView: View {
                     .foregroundStyle(.red)
             }
         }
+        .headerProminence(.increased)
     }
 
     // MARK: - Security
@@ -300,6 +311,7 @@ struct SettingsView: View {
                 PasskeyManagementView()
             }
         }
+        .headerProminence(.increased)
     }
 
     // MARK: - Bird Identification
@@ -315,11 +327,16 @@ struct SettingsView: View {
             }
         } header: {
             Text("Bird Identification")
+                .font(.headline)
+                .foregroundStyle(Color.foregroundText)
         } footer: {
             Text("Improves identification using photo location and month. Rounded coordinates may be sent to Geoapify to suggest outing names.")
                 .font(.footnote)
                 .foregroundStyle(Color.mutedText)
+                .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("settings.birdIdFooter")
         }
+            .headerProminence(.increased)
     }
 
     // MARK: - Legal
@@ -334,6 +351,7 @@ struct SettingsView: View {
                 Label("Terms of Use", systemImage: "doc.text")
             }
         }
+        .headerProminence(.increased)
     }
 
     // MARK: - Data Management
@@ -348,6 +366,7 @@ struct SettingsView: View {
                     .foregroundStyle(.red)
             }
         }
+        .headerProminence(.increased)
     }
 
     // MARK: - Development (DEBUG only)
@@ -373,6 +392,7 @@ struct SettingsView: View {
                     .foregroundStyle(.red)
             }
         }
+        .headerProminence(.increased)
         .alert(
             "Load Demo Data?",
             isPresented: $showingDemoConfirmation

--- a/ios/WingDex/Views/WingDexView.swift
+++ b/ios/WingDex/Views/WingDexView.swift
@@ -189,12 +189,16 @@ struct WingDexView: View {
                 }
                 VStack(spacing: 8) {
                     Text("No Species Yet")
-                        .font(.system(size: 22, weight: .semibold, design: .serif))
+                        .font(.title2)
+                        .fontDesign(.serif)
+                        .fontWeight(.semibold)
                         .foregroundStyle(Color.foregroundText)
+                        .fixedSize(horizontal: false, vertical: true)
                     Text("Species will appear here as you identify birds.")
-                        .font(.system(size: 15))
+                        .font(.body)
                         .foregroundStyle(Color.mutedText)
                         .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer()
             }

--- a/ios/WingDexTests/AccountDataCacheTests.swift
+++ b/ios/WingDexTests/AccountDataCacheTests.swift
@@ -74,6 +74,41 @@ final class AccountDataCacheTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: staleArtifactURL.path))
     }
 
+    func testValidDiskStoreSurvivesReopen() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = directory.appending(path: "WingDexCache.store")
+
+        do {
+            let cache = try AccountDataCache(storeURL: storeURL)
+            try cache.replace(accountID: "account-a", response: fixtureResponse(accountID: "account-a"))
+        }
+
+        let reopened = try AccountDataCache(storeURL: storeURL)
+        XCTAssertEqual(
+            try XCTUnwrap(reopened.load(accountID: "account-a")).response.outings.first?.userId,
+            "account-a"
+        )
+    }
+
+    func testDirectoryAtStorePathIsRecreated() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        let storeURL = directory.appending(path: "WingDexCache.store", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: storeURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let cache = try AccountDataCache(storeURL: storeURL)
+        try cache.replace(accountID: "account-a", response: fixtureResponse(accountID: "account-a"))
+
+        XCTAssertEqual(
+            try XCTUnwrap(cache.load(accountID: "account-a")).response.outings.first?.userId,
+            "account-a"
+        )
+    }
+
     func testDurablePurgeDenialPreventsHydrationAndRetriesDeletion() throws {
         let directory = FileManager.default.temporaryDirectory
             .appending(path: UUID().uuidString, directoryHint: .isDirectory)

--- a/ios/WingDexTests/AuthIntegrationTests.swift
+++ b/ios/WingDexTests/AuthIntegrationTests.swift
@@ -1,20 +1,10 @@
 @testable import WingDex
 import XCTest
 
-/// Integration tests that run against the actual API server.
-/// Requires the dev server to be running (localhost.wingdex.app or localhost:5000).
-///
-/// These tests use anonymous sign-in (no OAuth required) to verify
-/// the Bearer token auth flow works end-to-end from Swift code.
+/// Exercises anonymous bearer authentication against the selected API backend.
 final class AuthIntegrationTests: XCTestCase {
 
-    private let baseURL: URL = {
-        #if CI
-        URL(string: "http://localhost:5000")!
-        #else
-        Config.apiBaseURL
-        #endif
-    }()
+    private let baseURL = Config.apiBaseURL
     private let timeout: TimeInterval = 10
 
     // MARK: - Anonymous Sign-In + Bearer Auth
@@ -84,7 +74,7 @@ final class AuthIntegrationTests: XCTestCase {
         let token = try await signInAnonymously()
 
         // Create outing
-        let outingId = "integration-test-\(Int(Date.now.timeIntervalSince1970))"
+        let outingId = "integration-test-\(UUID().uuidString)"
         let createURL = baseURL.appendingPathComponent("api/data/outings")
         var createReq = URLRequest(url: createURL)
         createReq.httpMethod = "POST"

--- a/ios/WingDexUITests/BirdIdFlowUITests.swift
+++ b/ios/WingDexUITests/BirdIdFlowUITests.swift
@@ -10,12 +10,22 @@ final class BirdIdFlowUITests: XCTestCase {
     private static let photo = "Great_blue_heron_roosting_at_Carkeek_Park.jpg"
     private static let expectedSpecies = "Great Blue Heron"
 
-    private var localWorkerURL: URL {
-        #if CI
-        URL(string: "http://localhost:5000")!
-        #else
-        URL(string: "https://localhost.wingdex.app")!
-        #endif
+    private var configuredAPIBaseURLValue: String? {
+        ProcessInfo.processInfo.environment["API_BASE_URL"]
+    }
+
+    private var configuredAPIBaseURL: URL? {
+        guard let value = configuredAPIBaseURLValue,
+              let url = URL(string: value),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              url.host != nil
+        else { return nil }
+        return url
+    }
+
+    private var apiBaseURL: URL {
+        configuredAPIBaseURL ?? URL(string: "https://localhost.wingdex.app")!
     }
 
     private static var photoPath: String {
@@ -31,6 +41,9 @@ final class BirdIdFlowUITests: XCTestCase {
     /// failed run continue turns one broken assertion into minutes of dead waiting.
     override func setUp() {
         continueAfterFailure = false
+        if configuredAPIBaseURLValue != nil {
+            XCTAssertNotNil(configuredAPIBaseURL, "API_BASE_URL must be an absolute HTTP(S) URL")
+        }
     }
 
     /// XCTNSPredicateExpectation is unavailable under strict concurrency here, so poll.
@@ -73,11 +86,14 @@ final class BirdIdFlowUITests: XCTestCase {
         toggle.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.5)).tap()
     }
 
-    private func launchApp(
-        extraArguments: [String] = [],
-        extraEnvironment: [String: String] = [:]
-    ) -> XCUIApplication {
+    private func application() -> XCUIApplication {
         let app = XCUIApplication()
+        app.launchEnvironment["API_BASE_URL"] = apiBaseURL.absoluteString
+        return app
+    }
+
+    private func launchApp(extraArguments: [String] = []) -> XCUIApplication {
+        let app = application()
         app.launchArguments = [
             "--auto-sign-in",
             // Empty the account so leftover outings from earlier runs cannot change the
@@ -88,18 +104,12 @@ final class BirdIdFlowUITests: XCTestCase {
             "--ui-test-lat", "47.7115",
             "--ui-test-lon", "-122.3717",
         ] + extraArguments
-        app.launchEnvironment.merge(extraEnvironment) { _, newValue in newValue }
         app.launch()
         return app
     }
 
-    /// Why the local Worker could not be reached, or nil when it is healthy.
-    ///
-    /// Returns the reason rather than a bool so CI can put it in the failure
-    /// message. A bare false told us nothing on 2026-08-10, when this test skipped
-    /// because the simulator had not finished booting and the run stayed green.
-    private func localWorkerUnavailableReason() async -> String? {
-        let url = localWorkerURL.appendingPathComponent("api/health")
+    private func backendUnavailableReason() async -> String? {
+        let url = apiBaseURL.appendingPathComponent("api/health")
         do {
             let (data, response) = try await URLSession.shared.data(from: url)
             guard let http = response as? HTTPURLResponse else {
@@ -178,21 +188,14 @@ final class BirdIdFlowUITests: XCTestCase {
     }
 
     func testSubmittedPlaceSearchSelectsNormalizedResult() async throws {
-        if let reason = await localWorkerUnavailableReason() {
-            // Skipping is right on a laptop with no Worker running. It is wrong in
-            // CI, which provisions one on purpose: a skip there means the harness
-            // is broken, and reporting it as success is how the 2026-08-10 release
-            // failure went unnoticed until it reached the release job.
-            #if CI
-            XCTFail("Local Worker is required in CI but was not reachable. \(reason)")
-            return
-            #else
-            throw XCTSkip("Requires the current local WingDex Worker and Geoapify access. \(reason)")
-            #endif
+        if let reason = await backendUnavailableReason() {
+            guard configuredAPIBaseURLValue == nil else {
+                XCTFail("Selected CI backend is not healthy. \(reason)")
+                return
+            }
+            throw XCTSkip("Requires a healthy WingDex backend with Geoapify access. \(reason)")
         }
-        let app = launchApp(extraEnvironment: [
-            "API_BASE_URL": localWorkerURL.absoluteString,
-        ])
+        let app = launchApp()
         let continueButton = app.buttons["Continue"]
         XCTAssertTrue(continueButton.waitForExistence(timeout: 120))
         XCTAssertTrue(waitUntil(timeout: 15) { continueButton.isHittable })
@@ -233,17 +236,14 @@ final class BirdIdFlowUITests: XCTestCase {
     }
 
     func testFocusedEmptyLocationShowsNearbyPlacesWithoutKeyboard() async throws {
-        if let reason = await localWorkerUnavailableReason() {
-            #if CI
-            XCTFail("Local Worker is required in CI but was not reachable. \(reason)")
-            return
-            #else
-            throw XCTSkip("Requires the current local WingDex Worker and Geoapify access. \(reason)")
-            #endif
+        if let reason = await backendUnavailableReason() {
+            guard configuredAPIBaseURLValue == nil else {
+                XCTFail("Selected CI backend is not healthy. \(reason)")
+                return
+            }
+            throw XCTSkip("Requires a healthy WingDex backend with Geoapify access. \(reason)")
         }
-        let app = launchApp(extraEnvironment: [
-            "API_BASE_URL": localWorkerURL.absoluteString,
-        ])
+        let app = launchApp()
         let continueButton = app.buttons["Continue"]
         XCTAssertTrue(continueButton.waitForExistence(timeout: 120))
         XCTAssertTrue(waitUntil(timeout: 15) { continueButton.isHittable })
@@ -344,7 +344,7 @@ final class BirdIdFlowUITests: XCTestCase {
     }
 
     func testSignInPassesAccessibilityAudit() throws {
-        let app = XCUIApplication()
+        let app = application()
         app.launchArguments = ["--ui-test-sign-out"]
         app.launch()
         XCTAssertTrue(app.buttons["Continue with Apple"].waitForExistence(timeout: 30))
@@ -353,7 +353,7 @@ final class BirdIdFlowUITests: XCTestCase {
     }
 
     func testHomePassesAccessibilityAudit() throws {
-        let app = XCUIApplication()
+        let app = application()
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
         let homeTab = app.buttons["Home"]
@@ -383,7 +383,7 @@ final class BirdIdFlowUITests: XCTestCase {
     }
 
     func testWingDexPassesAccessibilityAudit() throws {
-        let app = XCUIApplication()
+        let app = application()
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
         let wingDexTab = app.buttons["WingDex"]
@@ -395,7 +395,7 @@ final class BirdIdFlowUITests: XCTestCase {
     }
 
     func testOutingsPassesAccessibilityAudit() throws {
-        let app = XCUIApplication()
+        let app = application()
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
         let outingsTab = app.buttons["Outings"]
@@ -407,7 +407,7 @@ final class BirdIdFlowUITests: XCTestCase {
     }
 
     func testSettingsAndDeletionConfirmationsPassAccessibilityAudit() throws {
-        let app = XCUIApplication()
+        let app = application()
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
         XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))

--- a/ios/WingDexUITests/BirdIdFlowUITests.swift
+++ b/ios/WingDexUITests/BirdIdFlowUITests.swift
@@ -9,6 +9,7 @@ final class BirdIdFlowUITests: XCTestCase {
     /// the repo rather than the app bundle so it never ships inside the app.
     private static let photo = "Great_blue_heron_roosting_at_Carkeek_Park.jpg"
     private static let expectedSpecies = "Great Blue Heron"
+    private static let avatarEmojiLabels: Set<String> = ["🐦", "🦉", "🦜", "🐧", "🦆", "🦩", "🦅", "🐤"]
 
     private var configuredAPIBaseURLValue: String? {
         ProcessInfo.processInfo.environment["API_BASE_URL"]
@@ -73,6 +74,57 @@ final class BirdIdFlowUITests: XCTestCase {
         field.value as? String ?? ""
     }
 
+    private func runAccessibilityAudit(
+        in app: XCUIApplication,
+        for auditTypes: XCUIAccessibilityAuditType = .all,
+        handlingKnownIssue: ((XCUIAccessibilityAuditIssue) -> Bool)? = nil
+    ) throws {
+        do {
+            try app.performAccessibilityAudit(for: auditTypes) { issue in
+                handlingKnownIssue?(issue) ?? false
+            }
+        } catch {
+            if Self.isAccessibilityAuditInfrastructureTimeout(error) {
+                XCTFail("XCTest accessibility audit infrastructure timed out before reporting results (Code=-56)")
+                return
+            }
+            throw error
+        }
+    }
+
+    nonisolated private static func isAccessibilityAuditInfrastructureTimeout(
+        _ error: Error
+    ) -> Bool {
+        let auditError = error as NSError
+        return auditError.domain == "com.apple.xcode.xctest.accessibilityAudit"
+            && auditError.code == -56
+    }
+
+    private func isKnownAddPhotosAuditIssue(_ issue: XCUIAccessibilityAuditIssue) -> Bool {
+        switch issue.auditType {
+        case .contrast:
+            return issue.element == nil && issue.compactDescription == "Contrast nearly passed"
+        case .dynamicType:
+            return issue.element?.identifier == "outing.photosHeader"
+        case .textClipped:
+            return issue.element?.identifier == "outing.locationName"
+        default:
+            return false
+        }
+    }
+
+    private func isKnownSettingsAuditIssue(_ issue: XCUIAccessibilityAuditIssue) -> Bool {
+        switch issue.auditType {
+        case .dynamicType:
+            return issue.element?.identifier == "settings.birdIdFooter"
+        case .textClipped:
+            return issue.element?.identifier == "settings.displayName"
+                || Self.avatarEmojiLabels.contains(issue.element?.label ?? "")
+        default:
+            return false
+        }
+    }
+
     private func waitForDataSetup(in app: XCUIApplication) {
         let elements = app.descendants(matching: .any)
         let complete = elements["ui-test.dataSetupComplete"]
@@ -87,8 +139,15 @@ final class BirdIdFlowUITests: XCTestCase {
     private func waitForDemoData(in app: XCUIApplication) {
         waitForDataSetup(in: app)
         let elements = app.descendants(matching: .any)
-        XCTAssertTrue(elements["Chalk-browed Mockingbird"].waitForExistence(timeout: 120))
+        XCTAssertTrue(elements["Chalk-browed Mockingbird"].waitForExistence(timeout: 10))
         XCTAssertTrue(elements["Eared Dove"].exists)
+    }
+
+    private func waitForOutingReview(in app: XCUIApplication) -> XCUIElement {
+        waitForDataSetup(in: app)
+        let continueButton = app.buttons["Continue"]
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 60), "Outing review never appeared")
+        return continueButton
     }
 
     /// An account can already hold an outing that matches the injected cluster, which
@@ -153,11 +212,7 @@ final class BirdIdFlowUITests: XCTestCase {
 
         let app = launchApp()
 
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(
-            continueButton.waitForExistence(timeout: 120),
-            "Never reached the outing review step"
-        )
+        let continueButton = waitForOutingReview(in: app)
         // The button stays disabled while the outing's location is resolving.
         XCTAssertTrue(
             waitUntil(timeout: 15) { continueButton.isHittable },
@@ -205,6 +260,18 @@ final class BirdIdFlowUITests: XCTestCase {
         XCTAssertNotEqual(confidence.label, "0%", "Confidence should never round away to zero")
     }
 
+    func testAccessibilityAuditTimeoutClassification() {
+        XCTAssertTrue(Self.isAccessibilityAuditInfrastructureTimeout(
+            NSError(domain: "com.apple.xcode.xctest.accessibilityAudit", code: -56)
+        ))
+        XCTAssertFalse(Self.isAccessibilityAuditInfrastructureTimeout(
+            NSError(domain: "com.apple.xcode.xctest.accessibilityAudit", code: -55)
+        ))
+        XCTAssertFalse(Self.isAccessibilityAuditInfrastructureTimeout(
+            NSError(domain: NSCocoaErrorDomain, code: -56)
+        ))
+    }
+
     func testSubmittedPlaceSearchSelectsNormalizedResult() async throws {
         if let reason = await backendUnavailableReason() {
             guard configuredAPIBaseURLValue == nil else {
@@ -214,8 +281,7 @@ final class BirdIdFlowUITests: XCTestCase {
             throw XCTSkip("Requires a healthy WingDex backend with Geoapify access. \(reason)")
         }
         let app = launchApp()
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(continueButton.waitForExistence(timeout: 120))
+        let continueButton = waitForOutingReview(in: app)
         XCTAssertTrue(waitUntil(timeout: 15) { continueButton.isHittable })
 
         startNewOuting(in: app)
@@ -262,8 +328,7 @@ final class BirdIdFlowUITests: XCTestCase {
             throw XCTSkip("Requires a healthy WingDex backend with Geoapify access. \(reason)")
         }
         let app = launchApp()
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(continueButton.waitForExistence(timeout: 120))
+        let continueButton = waitForOutingReview(in: app)
         XCTAssertTrue(waitUntil(timeout: 15) { continueButton.isHittable })
 
         startNewOuting(in: app)
@@ -292,8 +357,7 @@ final class BirdIdFlowUITests: XCTestCase {
             "--ui-test-geocoding-failure",
             "--ui-test-clear-last-location",
         ])
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(continueButton.waitForExistence(timeout: 120))
+        let continueButton = waitForOutingReview(in: app)
         XCTAssertTrue(waitUntil(timeout: 15) { continueButton.isHittable })
 
         startNewOuting(in: app)
@@ -320,11 +384,7 @@ final class BirdIdFlowUITests: XCTestCase {
 
     func testDismissingOutingReviewCancelsDelayedGeocoding() {
         let app = launchApp(extraArguments: ["--ui-test-geocoding-delay"])
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(
-            continueButton.waitForExistence(timeout: 120),
-            "Outing review never appeared"
-        )
+        let continueButton = waitForOutingReview(in: app)
         // Declining a matched outing is what starts the lookup for that account state.
         startNewOuting(in: app)
         XCTAssertFalse(continueButton.isEnabled, "Delayed geocoding was not in progress")
@@ -348,17 +408,10 @@ final class BirdIdFlowUITests: XCTestCase {
 
     func testAddPhotosOutingReviewPassesAccessibilityAudit() throws {
         let app = launchApp(extraArguments: ["--ui-test-geocoding-failure"])
-        let continueButton = app.buttons["Continue"]
-        XCTAssertTrue(continueButton.waitForExistence(timeout: 120))
+        let continueButton = waitForOutingReview(in: app)
         XCTAssertTrue(waitUntil(timeout: 15) { continueButton.isHittable })
 
-        try performBoundedAccessibilityAudit(
-            app: app,
-            // iOS 26 intermittently samples the native Form's Location header in addition
-            // to the existing system DatePicker contrast sample.
-            expectedContrastFindings: 2,
-            expectedDynamicTypeFindings: 4
-        )
+        try runAccessibilityAudit(in: app, handlingKnownIssue: isKnownAddPhotosAuditIssue)
     }
 
     func testSignInPassesAccessibilityAudit() throws {
@@ -367,89 +420,98 @@ final class BirdIdFlowUITests: XCTestCase {
         app.launch()
         XCTAssertTrue(app.buttons["Continue with Apple"].waitForExistence(timeout: 30))
 
-        try app.performAccessibilityAudit()
+        try runAccessibilityAudit(in: app)
     }
 
     func testHomePassesAccessibilityAudit() throws {
         let app = application()
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
-        let homeTab = app.buttons["Home"]
-        XCTAssertTrue(homeTab.waitForExistence(timeout: 120))
-        homeTab.tap()
-        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))
         waitForDemoData(in: app)
+        let homeTab = app.buttons["Home"]
+        XCTAssertTrue(homeTab.waitForExistence(timeout: 10))
+        homeTab.tap()
+        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 10))
 
-        var photoContrastFindings = 0
-        var contrastDetails: [String] = []
-        try app.performAccessibilityAudit { issue in
-            // XCTest samples photo-backed cells and one compact glyph without exposing their elements.
-            if issue.auditType == .contrast {
-                photoContrastFindings += 1
-            contrastDetails.append(String(describing: issue.element))
-                return true
-            }
-            return false
-        }
-        XCTAssertLessThanOrEqual(
-            photoContrastFindings,
-            6,
-            "Unexpected contrast samples: \(contrastDetails)"
-        )
+        try runAccessibilityAudit(in: app, for: .all.subtracting(.contrast))
+    }
+
+    func testEmptyHomePassesAccessibilityAudit() throws {
+        let app = application()
+        app.launchArguments = ["--auto-sign-in", "--ui-test-clear-data"]
+        app.launch()
+        waitForDataSetup(in: app)
+        XCTAssertTrue(app.staticTexts["Got bird pics?"].waitForExistence(timeout: 10))
+
+        try runAccessibilityAudit(in: app)
     }
 
     func testWingDexPassesAccessibilityAudit() throws {
         let app = application()
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
-        let wingDexTab = app.buttons["WingDex"]
-        XCTAssertTrue(wingDexTab.waitForExistence(timeout: 120))
         waitForDemoData(in: app)
+        let wingDexTab = app.buttons["WingDex"]
+        XCTAssertTrue(wingDexTab.waitForExistence(timeout: 10))
         wingDexTab.tap()
-        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))
+        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.descendants(matching: .any)["Chalk-browed Mockingbird"].waitForExistence(timeout: 10))
 
-        try performListAccessibilityAudit(app: app, expectedPhotoContrastFindings: 4)
+        try performListAccessibilityAudit(app: app, includesContrast: false)
     }
 
     func testEmptyWingDexPassesAccessibilityAudit() throws {
         let app = application()
         app.launchArguments = ["--auto-sign-in", "--ui-test-clear-data"]
         app.launch()
-        let wingDexTab = app.buttons["WingDex"]
-        XCTAssertTrue(wingDexTab.waitForExistence(timeout: 120))
         waitForDataSetup(in: app)
+        let wingDexTab = app.buttons["WingDex"]
+        XCTAssertTrue(wingDexTab.waitForExistence(timeout: 10))
         wingDexTab.tap()
-        XCTAssertTrue(app.staticTexts["No Species Yet"].waitForExistence(timeout: 120))
+        XCTAssertTrue(app.staticTexts["No Species Yet"].waitForExistence(timeout: 10))
 
-        try performListAccessibilityAudit(app: app, expectedPhotoContrastFindings: 0)
+        try performListAccessibilityAudit(app: app, includesContrast: true)
     }
 
     func testOutingsPassesAccessibilityAudit() throws {
         let app = application()
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
-        let outingsTab = app.buttons["Outings"]
-        XCTAssertTrue(outingsTab.waitForExistence(timeout: 120))
         waitForDemoData(in: app)
+        let outingsTab = app.buttons["Outings"]
+        XCTAssertTrue(outingsTab.waitForExistence(timeout: 10))
         outingsTab.tap()
-        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))
+        XCTAssertTrue(app.navigationBars["Outings"].waitForExistence(timeout: 10))
 
-        try performListAccessibilityAudit(app: app, expectedPhotoContrastFindings: 4)
+        try performListAccessibilityAudit(app: app, includesContrast: false)
+    }
+
+    func testEmptyOutingsPassesAccessibilityAudit() throws {
+        let app = application()
+        app.launchArguments = ["--auto-sign-in", "--ui-test-clear-data"]
+        app.launch()
+        waitForDataSetup(in: app)
+        let outingsTab = app.buttons["Outings"]
+        XCTAssertTrue(outingsTab.waitForExistence(timeout: 10))
+        outingsTab.tap()
+        XCTAssertTrue(app.navigationBars["Outings"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["No Outings Yet"].waitForExistence(timeout: 10))
+
+        try performListAccessibilityAudit(app: app, includesContrast: true)
     }
 
     func testSettingsAndDeletionConfirmationsPassAccessibilityAudit() throws {
         let app = application()
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
-        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))
         waitForDemoData(in: app)
+        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 10))
         app.buttons["Settings"].tap()
         XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 10))
-        try performBoundedAccessibilityAudit(
-            app: app,
-            expectedContrastFindings: 6,
-            expectedDynamicTypeFindings: 1
+        try runAccessibilityAudit(
+            in: app,
+            for: .all.subtracting(.contrast),
+            handlingKnownIssue: isKnownSettingsAuditIssue
         )
 
         let deleteData = app.buttons["Delete Data..."]
@@ -458,68 +520,49 @@ final class BirdIdFlowUITests: XCTestCase {
         }
         deleteData.tap()
         XCTAssertTrue(app.navigationBars["Data Management"].waitForExistence(timeout: 10))
-        try app.performAccessibilityAudit()
+        try runAccessibilityAudit(in: app)
 
         app.buttons["Delete Account & All Data"].tap()
         XCTAssertTrue(app.alerts["Delete your entire account?"].waitForExistence(timeout: 5))
-        try performBoundedAccessibilityAudit(
-            app: app,
-            expectedContrastFindings: 1,
-            expectedDynamicTypeFindings: 4
-        )
+        // UIKit alerts scale text but fail XCTest's Dynamic Type audit.
+        let nativeAlertAudits = XCUIAccessibilityAuditType.all.subtracting(.dynamicType)
+        try runAccessibilityAudit(in: app, for: nativeAlertAudits)
         app.alerts["Delete your entire account?"].buttons["I understand, continue"].tap()
         XCTAssertTrue(app.alerts["Are you absolutely sure?"].waitForExistence(timeout: 5))
-        try performBoundedAccessibilityAudit(
-            app: app,
-            expectedContrastFindings: 1,
-            expectedDynamicTypeFindings: 4
-        )
+        try runAccessibilityAudit(in: app, for: nativeAlertAudits)
         app.alerts["Are you absolutely sure?"].buttons["Go back"].tap()
     }
 
-    private func performBoundedAccessibilityAudit(
-        app: XCUIApplication,
-        expectedContrastFindings: Int = 0,
-        expectedDynamicTypeFindings: Int = 0
-    ) throws {
-        var contrastFindings = 0
-        var dynamicTypeFindings = 0
-        var contrastDetails: [String] = []
-        try app.performAccessibilityAudit { issue in
-            switch issue.auditType {
-            case .contrast:
-                contrastFindings += 1
-                contrastDetails.append(String(describing: issue.element))
-                return true
-            case .dynamicType:
-                dynamicTypeFindings += 1
-                return true
-            case .textClipped where issue.element?.elementType == .textField:
-                // A single-line text field scrolls its value instead of truncating it, and
-                // VoiceOver still reads the whole thing. The audit cannot model that.
-                return true
-            default:
-                return false
-            }
-        }
-        XCTAssertLessThanOrEqual(
-            contrastFindings,
-            expectedContrastFindings,
-            "Unexpected contrast samples: \(contrastDetails)"
-        )
-        XCTAssertLessThanOrEqual(dynamicTypeFindings, expectedDynamicTypeFindings)
+    func testSettingsPassesContrastAudit() throws {
+        let app = application()
+        app.launchArguments = [
+            "--auto-sign-in",
+            "--auto-demo-data",
+            "--ui-test-reset-data",
+            "--ui-test-hide-avatar-options",
+        ]
+        app.launch()
+        waitForDemoData(in: app)
+        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 10))
+        app.buttons["Settings"].tap()
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 10))
+
+        try runAccessibilityAudit(in: app, for: .contrast)
+
+        let legalHeader = app.staticTexts["Legal"]
+        XCTAssertTrue(scrollUntilVisible(legalHeader, in: app))
+        try runAccessibilityAudit(in: app, for: .contrast)
     }
 
     private func performListAccessibilityAudit(
         app: XCUIApplication,
-        expectedPhotoContrastFindings: Int
+        includesContrast: Bool
     ) throws {
-        var photoContrastFindings = 0
-        try app.performAccessibilityAudit { issue in
+        let auditTypes: XCUIAccessibilityAuditType = includesContrast
+            ? .all
+            : .all.subtracting(.contrast)
+        try runAccessibilityAudit(in: app, for: auditTypes) { issue in
             switch issue.auditType {
-            case .contrast:
-                photoContrastFindings += 1
-                return true
             case .dynamicType where issue.element?.label == "Sort":
                 return true
             case .textClipped where ["Search species", "Search outings", "Sort"].contains(issue.element?.label):
@@ -528,6 +571,5 @@ final class BirdIdFlowUITests: XCTestCase {
                 return false
             }
         }
-        XCTAssertLessThanOrEqual(photoContrastFindings, expectedPhotoContrastFindings)
     }
 }

--- a/ios/WingDexUITests/BirdIdFlowUITests.swift
+++ b/ios/WingDexUITests/BirdIdFlowUITests.swift
@@ -11,11 +11,11 @@ final class BirdIdFlowUITests: XCTestCase {
     private static let expectedSpecies = "Great Blue Heron"
     private static let avatarEmojiLabels: Set<String> = ["🐦", "🦉", "🦜", "🐧", "🦆", "🦩", "🦅", "🐤"]
 
-    private var configuredAPIBaseURLValue: String? {
+    nonisolated private var configuredAPIBaseURLValue: String? {
         ProcessInfo.processInfo.environment["API_BASE_URL"]
     }
 
-    private var configuredAPIBaseURL: URL? {
+    nonisolated private var configuredAPIBaseURL: URL? {
         guard let value = configuredAPIBaseURLValue,
               let url = URL(string: value),
               let scheme = url.scheme?.lowercased(),

--- a/ios/WingDexUITests/BirdIdFlowUITests.swift
+++ b/ios/WingDexUITests/BirdIdFlowUITests.swift
@@ -73,6 +73,24 @@ final class BirdIdFlowUITests: XCTestCase {
         field.value as? String ?? ""
     }
 
+    private func waitForDataSetup(in app: XCUIApplication) {
+        let elements = app.descendants(matching: .any)
+        let complete = elements["ui-test.dataSetupComplete"]
+        let failed = elements["ui-test.dataSetupFailed"]
+        XCTAssertTrue(
+            waitUntil(timeout: 120) { complete.exists || failed.exists },
+            "UI test data setup did not finish"
+        )
+        XCTAssertFalse(failed.exists, "UI test data setup failed")
+    }
+
+    private func waitForDemoData(in app: XCUIApplication) {
+        waitForDataSetup(in: app)
+        let elements = app.descendants(matching: .any)
+        XCTAssertTrue(elements["Chalk-browed Mockingbird"].waitForExistence(timeout: 120))
+        XCTAssertTrue(elements["Eared Dove"].exists)
+    }
+
     /// An account can already hold an outing that matches the injected cluster, which
     /// inherits its location instead of offering an editable one. Start from a new outing.
     private func startNewOuting(in app: XCUIApplication) {
@@ -360,9 +378,7 @@ final class BirdIdFlowUITests: XCTestCase {
         XCTAssertTrue(homeTab.waitForExistence(timeout: 120))
         homeTab.tap()
         XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))
-        let elements = app.descendants(matching: .any)
-        XCTAssertTrue(elements["Chalk-browed Mockingbird"].waitForExistence(timeout: 10))
-        XCTAssertTrue(elements["Eared Dove"].exists)
+        waitForDemoData(in: app)
 
         var photoContrastFindings = 0
         var contrastDetails: [String] = []
@@ -388,10 +404,25 @@ final class BirdIdFlowUITests: XCTestCase {
         app.launch()
         let wingDexTab = app.buttons["WingDex"]
         XCTAssertTrue(wingDexTab.waitForExistence(timeout: 120))
+        waitForDemoData(in: app)
         wingDexTab.tap()
         XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))
+        XCTAssertTrue(app.descendants(matching: .any)["Chalk-browed Mockingbird"].waitForExistence(timeout: 10))
 
         try performListAccessibilityAudit(app: app, expectedPhotoContrastFindings: 4)
+    }
+
+    func testEmptyWingDexPassesAccessibilityAudit() throws {
+        let app = application()
+        app.launchArguments = ["--auto-sign-in", "--ui-test-clear-data"]
+        app.launch()
+        let wingDexTab = app.buttons["WingDex"]
+        XCTAssertTrue(wingDexTab.waitForExistence(timeout: 120))
+        waitForDataSetup(in: app)
+        wingDexTab.tap()
+        XCTAssertTrue(app.staticTexts["No Species Yet"].waitForExistence(timeout: 120))
+
+        try performListAccessibilityAudit(app: app, expectedPhotoContrastFindings: 0)
     }
 
     func testOutingsPassesAccessibilityAudit() throws {
@@ -400,6 +431,7 @@ final class BirdIdFlowUITests: XCTestCase {
         app.launch()
         let outingsTab = app.buttons["Outings"]
         XCTAssertTrue(outingsTab.waitForExistence(timeout: 120))
+        waitForDemoData(in: app)
         outingsTab.tap()
         XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))
 
@@ -411,6 +443,7 @@ final class BirdIdFlowUITests: XCTestCase {
         app.launchArguments = ["--auto-sign-in", "--auto-demo-data", "--ui-test-reset-data"]
         app.launch()
         XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 120))
+        waitForDemoData(in: app)
         app.buttons["Settings"].tap()
         XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 10))
         try performBoundedAccessibilityAudit(
@@ -482,26 +515,19 @@ final class BirdIdFlowUITests: XCTestCase {
         expectedPhotoContrastFindings: Int
     ) throws {
         var photoContrastFindings = 0
-        var systemDynamicTypeFindings = 0
-        var systemClippingFindings = 0
         try app.performAccessibilityAudit { issue in
-            // The iOS 26 audit flags the native search field and Sort menu while scaling them correctly.
             switch issue.auditType {
             case .contrast:
                 photoContrastFindings += 1
                 return true
-            case .dynamicType:
-                systemDynamicTypeFindings += 1
+            case .dynamicType where issue.element?.label == "Sort":
                 return true
-            case .textClipped:
-                systemClippingFindings += 1
+            case .textClipped where ["Search species", "Search outings", "Sort"].contains(issue.element?.label):
                 return true
             default:
                 return false
             }
         }
         XCTAssertLessThanOrEqual(photoContrastFindings, expectedPhotoContrastFindings)
-        XCTAssertLessThanOrEqual(systemDynamicTypeFindings, 1)
-        XCTAssertLessThanOrEqual(systemClippingFindings, 2)
     }
 }

--- a/ios/scripts/bump-version.sh
+++ b/ios/scripts/bump-version.sh
@@ -77,16 +77,32 @@ sed_inplace() {
 sed_inplace "s/MARKETING_VERSION: \".*\"/MARKETING_VERSION: \"${new_version}\"/" "$FILE"
 sed_inplace "s/CURRENT_PROJECT_VERSION: .*/CURRENT_PROJECT_VERSION: ${new_build}/" "$FILE"
 
-# Regenerate .xcodeproj so pbxproj stays in sync with project.yml
+generated_project_matches() {
+  local project_file="WingDex.xcodeproj/project.pbxproj"
+  awk -v version="${new_version};" -v build="${new_build};" '
+    $1 == "MARKETING_VERSION" && $2 == "=" {
+      versions += 1
+      if ($3 != version) invalid = 1
+    }
+    $1 == "CURRENT_PROJECT_VERSION" && $2 == "=" {
+      builds += 1
+      if ($3 != build) invalid = 1
+    }
+    END { exit !(versions > 0 && builds > 0 && invalid == 0) }
+  ' "$project_file" 2>/dev/null
+}
+
 if command -v xcodegen &> /dev/null; then
   [[ "$QUIET" == false ]] && echo "Running xcodegen..."
   xcodegen generate
 else
-  if [[ "${CI:-}" == "true" ]]; then
+  if [[ "${CI:-}" == "true" ]] && ! generated_project_matches; then
     echo "Error: xcodegen is required in CI to keep the generated project in sync" >&2
     exit 1
   fi
-  [[ "$QUIET" == false ]] && echo "Warning: xcodegen not found - run it manually to sync the .xcodeproj"
+  if [[ "${CI:-}" != "true" ]]; then
+    [[ "$QUIET" == false ]] && echo "Warning: xcodegen not found - run it manually to sync the .xcodeproj"
+  fi
 fi
 
 if [[ "$QUIET" == true ]]; then

--- a/ios/scripts/install-xcodegen.sh
+++ b/ios/scripts/install-xcodegen.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VERSION="2.46.0"
+SHA256="4d9e34b62172d645eed6457cac13fc222569974098ef4ee9c3368bedf0196806"
+INSTALL_ROOT="${RUNNER_TEMP:-/tmp}/xcodegen-${VERSION}"
+ARCHIVE="${INSTALL_ROOT}.zip"
+
+rm -rf "$INSTALL_ROOT" "$ARCHIVE"
+mkdir -p "$INSTALL_ROOT"
+
+curl --fail --silent --show-error --location --retry 3 \
+  --output "$ARCHIVE" \
+  "https://github.com/yonaskolb/XcodeGen/releases/download/${VERSION}/xcodegen.zip"
+echo "${SHA256}  ${ARCHIVE}" | shasum --algorithm 256 --check
+unzip -q "$ARCHIVE" -d "$INSTALL_ROOT"
+
+mkdir -p "$INSTALL_ROOT/install"
+PREFIX="$INSTALL_ROOT/install" bash "$INSTALL_ROOT/xcodegen/install.sh"
+echo "$INSTALL_ROOT/install/bin" >> "${GITHUB_PATH:?}"
+"$INSTALL_ROOT/install/bin/xcodegen" --version


### PR DESCRIPTION
Rebuild iOS CI around deployed backends so the PR check and release path no longer depend on a local Wrangler process on macOS.

- require the exact current PR preview deployment, with no silent dev fallback
- pass one backend URL through the test runner and every launched app
- overlap simulator first boot with build setup and retain Xcode diagnostics
- gate releases on an existing successful iOS check instead of rerunning tests
- make root Release the explicit exact-SHA orchestrator for backend deployment and iOS release
- separate archive/export, semantic publication, and TestFlight upload into retryable jobs
- recover partial semantic-release states and ambiguous TestFlight uploads idempotently
- classify XCTest accessibility audit infrastructure timeout `Code=-56`
- replace numeric audit budgets with exact identifiers/labels and companion contrast states
- fix the app-owned clipping, header contrast, and decorative-label issues those audits exposed
- replace broad 120-second element waits with setup readiness plus measured post-readiness bounds
- trim Homebrew/XcodeGen and duplicate package-resolution setup

Tracks #314 steps 3-5 and incorporates the overlapping speed work from #312. #319 remains a non-blocking test-account hygiene follow-up.

The Dynamic Type failure from release run 31439954116 attempt 1 was a test race: the retained recording showed the audit running on the empty WingDex screen before demo data reset completed. Attempt 2 was separate: the local-Worker place-search result arrived about 80 seconds after submission, after the 30-second assertion had failed. The same test against a deployed preview passed in 24 seconds.

Validation:
- `actionlint` with `shellcheck` across all affected workflows
- clean Xcode `build-for-testing`
- 10 populated/empty/companion accessibility states pass together from one clean build
- timeout classifier regression test passes
- representative integration, place-search, and UI tests pass against a deployed PR preview
- release routing, stale-source, partial-publication, generated-file, IPA metadata, and ambiguous-upload paths exercised locally
- all review threads addressed and resolved

Issue bodies for #314, #312, and #319 now reflect completed, superseded, and remaining work.